### PR TITLE
Systemd Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ API is healthy, versions: package='0.2.0' api='1.0.0'
 If necessary, you can check the logs from the service:
 
 ```
-$ journalctl --user-unit vplan
+$ journalctl --pager-end --user-unit vplan
 ```
 
 If you do need to change any of the systemd config files (unlikely), make sure

--- a/config/installed/systemd/user/vplan.service
+++ b/config/installed/systemd/user/vplan.service
@@ -7,6 +7,7 @@ After=network.target
 ExecStart=%h/.local/bin/uvicorn vplan.engine.server:API     \
           --uds %h/.config/vplan/server/run/engine.sock     \
           --log-config %h/.config/vplan/server/logging.yaml
+SyslogIdentifier=vplan
 WorkingDirectory=~
 Environment=PYTHONUNBUFFERED=1
 Environment=VPLAN_CONFIG_PATH=%h/.config/vplan/server/application.yaml

--- a/config/installed/vplan/server/logging.yaml
+++ b/config/installed/vplan/server/logging.yaml
@@ -3,7 +3,7 @@ disable_existing_loggers: false
 
 formatters:
   standard:
-    format: "%(levelname): %(message)s"
+    format: "%(levelname)s %(message)s"
 
 handlers:
   console:

--- a/config/installed/vplan/server/logging.yaml
+++ b/config/installed/vplan/server/logging.yaml
@@ -3,8 +3,7 @@ disable_existing_loggers: false
 
 formatters:
   standard:
-    format: "%(asctime)s.%(msecs)03d [%(levelname)-7s] %(message)s"
-    datefmt: "%Y-%m-%dT%H:%M:%S"
+    format: "%(levelname): %(message)s"
 
 handlers:
   console:


### PR DESCRIPTION
Improvements based on a week of running the service live:

- Simplify the logging format, since systemd logs already include a timestamp
- Change the name of the syslog identifier `uvicorn` to `vplan`, to make the log messages more clearly identifiable
- Adjust the recommended `journalctl` command in `README.md`