### PR TITLE
Add retry logic for job refresh

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -21,6 +21,9 @@ warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
+# See: https://github.com/python/mypy/issues/8754#issuecomment-622376701
+implicit_reexport = True
+
 # It's hard to make tests compliant using unittest.mock
 [mypy-tests.*]
 check_untyped_defs = False

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.5.0     unreleased
+
+	* Improve failure logging and add retry behavior for the daily refresh job.
+
 Version 0.4.1     30 Apr 2022
 
 	* Adjust the pyproject.toml include directive to limit what goes into wheel.

--- a/config/installed/vplan/server/application.yaml
+++ b/config/installed/vplan/server/application.yaml
@@ -8,3 +8,7 @@ scheduler:
    daily_job:
       jitter_sec: 0            # run jobs exactly when scheduled
       misfire_grace_sec: 1800  # if missed (i.e. if server is down), job will be run up to 30 minutes late
+retry:
+   max_attempts: 6  # retry the daily job up to 6 times with exponential backoff
+   min_sec: 10      # wait 10 seconds for first retry
+   max_sec: 60      # limit the retry wait to 60 seconds (i.e. 10, 20, 40, 60, 60, etc.)

--- a/config/installed/vplan/server/application.yaml
+++ b/config/installed/vplan/server/application.yaml
@@ -9,6 +9,6 @@ scheduler:
       jitter_sec: 0            # run jobs exactly when scheduled
       misfire_grace_sec: 1800  # if missed (i.e. if server is down), job will be run up to 30 minutes late
 retry:
-   max_attempts: 6  # retry the daily job up to 6 times with exponential backoff
-   min_sec: 10      # wait 10 seconds for first retry
-   max_sec: 60      # limit the retry wait to 60 seconds (i.e. 10, 20, 40, 60, 60, etc.)
+   max_attempts: 6  # attempt the daily job up to 6 times total (i.e. 5 retries) with exponential backoff
+   min_sec: 10      # wait 10 seconds before the first retry
+   max_sec: 60      # limit wait between retry attempts to 60 seconds (i.e. 10, 20, 40, 60, 60, etc.)

--- a/config/local/vplan/server/application.yaml
+++ b/config/local/vplan/server/application.yaml
@@ -8,3 +8,7 @@ scheduler:
    daily_job:
       jitter_sec: 0            # run jobs exactly when scheduled
       misfire_grace_sec: 1800  # if missed (i.e. if server is down), job will be run up to 30 minutes late
+retry:
+   max_attempts: 4  # retry the daily job up to 4 times with exponential backoff
+   min_sec: 1       # wait 1 second for first retry
+   max_sec: 5       # limit the retry wait to 5 seconds (i.e. 1, 2, 4, 5, 5, etc.)

--- a/config/local/vplan/server/application.yaml
+++ b/config/local/vplan/server/application.yaml
@@ -9,6 +9,6 @@ scheduler:
       jitter_sec: 0            # run jobs exactly when scheduled
       misfire_grace_sec: 1800  # if missed (i.e. if server is down), job will be run up to 30 minutes late
 retry:
-   max_attempts: 4  # retry the daily job up to 4 times with exponential backoff
-   min_sec: 1       # wait 1 second for first retry
-   max_sec: 5       # limit the retry wait to 5 seconds (i.e. 1, 2, 4, 5, 5, etc.)
+   max_attempts: 4  # attempt the daily job up to 4 times total (i.e. 3 retries) with exponential backoff
+   min_sec: 1       # wait 1 second before the first retry
+   max_sec: 5       # limit wait between retry attempts to 5 seconds (i.e. 1, 2, 4, 5, 5, etc.)

--- a/poetry.lock
+++ b/poetry.lock
@@ -358,14 +358,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "opnieuw"
-version = "1.2.0"
-description = "Retries for humans"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -691,6 +683,17 @@ anyio = ">=3.0.0,<4"
 full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests"]
 
 [[package]]
+name = "tenacity"
+version = "8.0.1"
+description = "Retry code until it succeeds"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -845,7 +848,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<4"
-content-hash = "463c0850c7360f0ae99a219c2261a9ee8efeafd4ba6d64b52447b6fe053bd0c1"
+content-hash = "86b626d72afbc3549af225e1aabb543c90d5db9bade30ef85ee118f9553495fd"
 
 [metadata.files]
 anyio = [
@@ -1135,10 +1138,6 @@ nodeenv = [
     {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
-opnieuw = [
-    {file = "opnieuw-1.2.0-py3-none-any.whl", hash = "sha256:c2784d342af982f3197637207001d7b3025ca0129101fd1c5014cdcfaf10edf4"},
-    {file = "opnieuw-1.2.0.tar.gz", hash = "sha256:2db9230af2146129194af549f7f7c5fb692caa681caf12fe9a81518e2a66d5cf"},
-]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -1336,6 +1335,10 @@ sqlalchemy2-stubs = [
 starlette = [
     {file = "starlette-0.17.1-py3-none-any.whl", hash = "sha256:26a18cbda5e6b651c964c12c88b36d9898481cd428ed6e063f5f29c418f73050"},
     {file = "starlette-0.17.1.tar.gz", hash = "sha256:57eab3cc975a28af62f6faec94d355a410634940f10b30d68d31cb5ec1b44ae8"},
+]
+tenacity = [
+    {file = "tenacity-8.0.1-py3-none-any.whl", hash = "sha256:f78f4ea81b0fabc06728c11dc2a8c01277bfc5181b321a4770471902e3eb844a"},
+    {file = "tenacity-8.0.1.tar.gz", hash = "sha256:43242a20e3e73291a28bcbcacfd6e000b02d3857a9a9fff56b297a27afdc932f"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -358,6 +358,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "opnieuw"
+version = "1.2.0"
+description = "Retries for humans"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -837,7 +845,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<4"
-content-hash = "cc2c6444363877273f7a710ae7f9e9b0d509264b6937eb7ebcc8164222d8ced8"
+content-hash = "463c0850c7360f0ae99a219c2261a9ee8efeafd4ba6d64b52447b6fe053bd0c1"
 
 [metadata.files]
 anyio = [
@@ -1126,6 +1134,10 @@ mypy-extensions = [
 nodeenv = [
     {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
+]
+opnieuw = [
+    {file = "opnieuw-1.2.0-py3-none-any.whl", hash = "sha256:c2784d342af982f3197637207001d7b3025ca0129101fd1c5014cdcfaf10edf4"},
+    {file = "opnieuw-1.2.0.tar.gz", hash = "sha256:2db9230af2146129194af549f7f7c5fb692caa681caf12fe9a81518e2a66d5cf"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ requests-unixsocket = "^0.3.0"
 SQLAlchemy = "^1.4.36"
 APScheduler = "^3.9.1"
 python-dotenv = "^0.20.0"
+opnieuw = "^1.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ requests-unixsocket = "^0.3.0"
 SQLAlchemy = "^1.4.36"
 APScheduler = "^3.9.1"
 python-dotenv = "^0.20.0"
-opnieuw = "^1.2.0"
+tenacity = "^8.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/src/vplan/engine/config.py
+++ b/src/vplan/engine/config.py
@@ -34,6 +34,14 @@ class DailyJobConfig(YamlModel):
     misfire_grace_sec: NonNegativeInt = Field(..., description="Misfire grace period in seconds, if job can't be run on time")
 
 
+class RetryConfig(YamlModel):
+    """Retry configuration."""
+
+    max_attempts: NonNegativeInt = Field(..., description="Maximum number of retry attempts for the daily job")
+    min_sec: NonNegativeInt = Field(..., description="Minimum delay for the retry exponential backoff, in seconds")
+    max_sec: NonNegativeInt = Field(..., description="Maximum delay for the retry exponential backoff, in seconds")
+
+
 class SchedulerConfig(YamlModel):
     """Scheduler configuration."""
 
@@ -42,7 +50,7 @@ class SchedulerConfig(YamlModel):
 
 
 class SmartThingsConfig(YamlModel):
-    """Scheduler configuration."""
+    """SmartThings API configuration."""
 
     base_api_url: str = Field(..., description="URL for the SmartThings API")
 
@@ -55,6 +63,7 @@ class ServerConfig(YamlModel):
     database_log_level: LogLevel = Field(..., description="The log level to use for database messages from SQLAlchemy")
     smartthings: SmartThingsConfig = Field(..., description="Configuration for the SmartThings interface")
     scheduler: SchedulerConfig = Field(..., description="Scheduler configuration")
+    retry: RetryConfig = Field(..., description="Retry configuration")
 
 
 _CONFIG: Optional[ServerConfig] = None

--- a/src/vplan/engine/config.py
+++ b/src/vplan/engine/config.py
@@ -37,7 +37,7 @@ class DailyJobConfig(YamlModel):
 class RetryConfig(YamlModel):
     """Retry configuration."""
 
-    max_attempts: NonNegativeInt = Field(..., description="Maximum number of retry attempts for the daily job")
+    max_attempts: NonNegativeInt = Field(..., description="Maximum number of attempts for the daily job, including initial attempt")
     min_sec: NonNegativeInt = Field(..., description="Minimum delay for the retry exponential backoff, in seconds")
     max_sec: NonNegativeInt = Field(..., description="Maximum delay for the retry exponential backoff, in seconds")
 

--- a/src/vplan/engine/manager.py
+++ b/src/vplan/engine/manager.py
@@ -124,4 +124,4 @@ def refresh_plan(plan_name: str, location: str) -> None:
     except Exception:  # pylint: disable=broad-except
 
         # We want the job to always succeed, and just log information on failure
-        logging.error("Refresh failed")
+        logging.exception("Refresh failed")

--- a/src/vplan/engine/smartthings.py
+++ b/src/vplan/engine/smartthings.py
@@ -47,6 +47,7 @@ from vplan.interface import (
 )
 
 
+# noinspection PyMethodMayBeStatic
 class LocationContext:
 
     """
@@ -59,7 +60,7 @@ class LocationContext:
     rooms, and devices and create our mappings before we do API calls that need
     to do lookups.  Rather than putting this burden on individual API calls,
     it's simpler to do all of the work up front and make everything available
-    via a Python context manager.  At least it's only 3 API calls.
+    via a Python context manager.  At least it's only a few API calls.
 
     Most of these APIs allow for pagination. Instead of dealing with that,
     I'm just using really big pages, so I can make a single request.  Most
@@ -93,13 +94,9 @@ class LocationContext:
     def _derive_location_id(self, location: str) -> str:
         """Derive the location id for a location name."""
         locations = {}
-        url = _url("/locations")
-        params = {"limit": LocationContext.LOCATION_LIMIT}
-        response = requests.get(url=url, headers=self.headers, params=params)
-        _raise_for_status(response)
-        if "items" in response.json():
-            for item in response.json()["items"]:
-                locations[item["name"]] = item["locationId"]
+        result = self._retrieve_locations()
+        for item in result:
+            locations[item["name"]] = item["locationId"]
         if not location in locations:
             raise SmartThingsClientError("Configured location not found: %s" % location)
         lid: str = locations[location]
@@ -110,14 +107,10 @@ class LocationContext:
         """Derive the mapping from room id->name and name->id for the location."""
         room_by_id = {}
         room_by_name = {}
-        url = _url("/locations/%s/rooms" % self.location_id)
-        params = {"limit": LocationContext.ROOM_LIMIT}
-        response = requests.get(url=url, headers=self.headers, params=params)
-        _raise_for_status(response)
-        if "items" in response.json():
-            for item in response.json()["items"]:
-                room_by_id[item["roomId"]] = item["name"]
-                room_by_name[item["name"]] = item["roomId"]
+        result = self._retrieve_rooms()
+        for item in result:
+            room_by_id[item["roomId"]] = item["name"]
+            room_by_name[item["name"]] = item["roomId"]
         logging.info("Location [%s] has %d rooms", self.location, len(room_by_id))
         if room_by_id:
             logging.debug("Rooms by id: %s", json.dumps(room_by_id, indent=2))
@@ -127,18 +120,14 @@ class LocationContext:
         """Derive the mapping from device id->Device and name->id for the location."""
         device_by_id = {}
         device_by_name = {}
-        url = _url("/devices")
-        params = {"locationId": self.location_id, "capability": "switch", "limit": LocationContext.DEVICE_LIMIT}
-        response = requests.get(url=url, headers=self.headers, params=params)
-        _raise_for_status(response)
-        if "items" in response.json():
-            for item in response.json()["items"]:
-                did = item["deviceId"]
-                device_name = item["label"] if item["label"] else item["name"]  # users see the label, if there is one
-                room_name = self.room_by_id[item["roomId"]]
-                device = Device(room=room_name, device=device_name)
-                device_by_id[did] = device
-                device_by_name["%s/%s" % (room_name, device.device)] = did
+        result = self._retrieve_devices()
+        for item in result:
+            did = item["deviceId"]
+            device_name = item["label"] if item["label"] else item["name"]  # users see the label, if there is one
+            room_name = self.room_by_id[item["roomId"]]
+            device = Device(room=room_name, device=device_name)
+            device_by_id[did] = device
+            device_by_name["%s/%s" % (room_name, device.device)] = did
         logging.info("Location [%s] has %d devices", self.location, len(device_by_id))
         if device_by_name:
             logging.debug("Devices by name:\n%s", json.dumps(device_by_name, indent=2))
@@ -147,19 +136,51 @@ class LocationContext:
     def _derive_rule_by_id(self) -> Dict[str, Dict[str, Any]]:
         """Derive the mapping from rule id->name, including only rules managed by us."""
         rule_by_id = {}
-        url = _url("/rules")
-        params = {"locationId": self.location_id, "limit": LocationContext.RULES_LIMIT}
-        response = requests.get(url=url, headers=self.headers, params=params)
-        _raise_for_status(response)
-        if "items" in response.json():
-            for item in response.json()["items"]:
-                if item["name"].startswith("%s/" % VPLAN_RULE_PREFIX):  # we identify our rules by name
-                    rule_id = item["id"]
-                    rule_by_id[rule_id] = item
+        result = self._retrieve_rules()
+        for item in result:
+            if item["name"].startswith("%s/" % VPLAN_RULE_PREFIX):  # we identify our rules by name
+                rule_id = item["id"]
+                rule_by_id[rule_id] = item
         logging.info("Location [%s] has %d managed rules", self.location, len(rule_by_id))
         if rule_by_id:
             logging.debug("Managed rules by id:\n%s", json.dumps(rule_by_id, indent=2))
         return rule_by_id
+
+    def _retrieve_locations(self) -> List[Dict[str, Any]]:
+        """Retrieve all locations associated with a token."""
+        url = _url("/locations")
+        params = {"limit": LocationContext.LOCATION_LIMIT}
+        response = requests.get(url=url, headers=self.headers, params=params)
+        _raise_for_status(response)
+        result = response.json()
+        return result["items"] if "items" in result else []  # type: ignore
+
+    def _retrieve_rooms(self) -> List[Dict[str, Any]]:
+        """Retrieve all rooms associated with a token."""
+        url = _url("/locations/%s/rooms" % self.location_id)
+        params = {"limit": LocationContext.ROOM_LIMIT}
+        response = requests.get(url=url, headers=self.headers, params=params)
+        _raise_for_status(response)
+        result = response.json()
+        return result["items"] if "items" in result else []  # type: ignore
+
+    def _retrieve_devices(self) -> List[Dict[str, Any]]:
+        """Retrieve all devices associated with a token."""
+        url = _url("/devices")
+        params = {"locationId": self.location_id, "capability": "switch", "limit": LocationContext.DEVICE_LIMIT}
+        response = requests.get(url=url, headers=self.headers, params=params)
+        _raise_for_status(response)
+        result = response.json()
+        return result["items"] if "items" in result else []  # type: ignore
+
+    def _retrieve_rules(self) -> List[Dict[str, Any]]:
+        """Retrieve all rules associated with a token."""
+        url = _url("/rules")
+        params = {"locationId": self.location_id, "limit": LocationContext.RULES_LIMIT}
+        response = requests.get(url=url, headers=self.headers, params=params)
+        _raise_for_status(response)
+        result = response.json()
+        return result["items"] if "items" in result else []  # type: ignore
 
 
 # Context managed by the SmartThings context manager

--- a/src/vplan/engine/smartthings.py
+++ b/src/vplan/engine/smartthings.py
@@ -23,7 +23,6 @@ from datetime import datetime
 from random import randint
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import opnieuw
 import requests
 
 from vplan.engine.config import config
@@ -45,18 +44,6 @@ from vplan.interface import (
     TriggerVariation,
 )
 
-# Implements exponential backoff with jitter for up to 5 calls in 45 seconds of max elapsed time
-# For more information see: https://pypi.org/project/opnieuw/
-RETRY = opnieuw.retry(
-    max_calls_total=5,
-    retry_window_after_first_call_in_seconds=45,
-    retry_on_exceptions=(
-        SmartThingsClientError,
-        opnieuw.RetryException,
-        requests.models.ConnectionError,
-        requests.models.HTTPError,
-    ),
-)
 
 # noinspection PyMethodMayBeStatic
 class LocationContext:
@@ -157,7 +144,6 @@ class LocationContext:
             logging.debug("Managed rules by id:\n%s", json.dumps(rule_by_id, indent=2))
         return rule_by_id
 
-    @RETRY
     def _retrieve_locations(self) -> List[Dict[str, Any]]:
         """Retrieve all locations associated with a token."""
         url = _url("/locations")
@@ -167,7 +153,6 @@ class LocationContext:
         result = response.json()
         return result["items"] if "items" in result else []  # type: ignore
 
-    @RETRY
     def _retrieve_rooms(self) -> List[Dict[str, Any]]:
         """Retrieve all rooms associated with a token."""
         url = _url("/locations/%s/rooms" % self.location_id)
@@ -177,7 +162,6 @@ class LocationContext:
         result = response.json()
         return result["items"] if "items" in result else []  # type: ignore
 
-    @RETRY
     def _retrieve_devices(self) -> List[Dict[str, Any]]:
         """Retrieve all devices associated with a token."""
         url = _url("/devices")
@@ -187,7 +171,6 @@ class LocationContext:
         result = response.json()
         return result["items"] if "items" in result else []  # type: ignore
 
-    @RETRY
     def _retrieve_rules(self) -> List[Dict[str, Any]]:
         """Retrieve all rules associated with a token."""
         url = _url("/rules")
@@ -342,7 +325,6 @@ def replace_rules(plan_name: str, schema: Optional[PlanSchema]) -> None:
     replace_managed_rules(plan_name, created)
 
 
-@RETRY
 def delete_rule(rule_id: str) -> None:
     """Delete an existing rule."""
     url = _url("/rules/%s" % rule_id)
@@ -351,7 +333,6 @@ def delete_rule(rule_id: str) -> None:
     _raise_for_status(response)
 
 
-@RETRY
 def create_rule(rule: Dict[str, Any]) -> Dict[str, Any]:
     """Create a rule, returning the result from SmartThings."""
     url = _url("/rules")
@@ -361,7 +342,6 @@ def create_rule(rule: Dict[str, Any]) -> Dict[str, Any]:
     return response.json()  # type: ignore[no-any-return]
 
 
-@RETRY
 def set_switch(device: Device, state: SwitchState) -> None:
     """Switch a device on or off."""
     command = "on" if state == SwitchState.ON else "off"
@@ -371,7 +351,6 @@ def set_switch(device: Device, state: SwitchState) -> None:
     _raise_for_status(response)
 
 
-@RETRY
 def check_switch(device: Device) -> SwitchState:
     """Check the state of a switch."""
     url = _url("/devices/%s/components/main/capabilities/switch/status" % device_id(device))

--- a/tests/engine/fixtures/config/application.yaml
+++ b/tests/engine/fixtures/config/application.yaml
@@ -8,3 +8,7 @@ scheduler:
    daily_job:
       jitter_sec: 300
       misfire_grace_sec: 1800
+retry:
+   max_attempts: 4
+   min_sec: 1
+   max_sec: 5

--- a/tests/engine/test_config.py
+++ b/tests/engine/test_config.py
@@ -53,3 +53,6 @@ class TestConfig:
         assert result.scheduler.database_url == "sqlite+pysqlite:///.runtime/db/jobs.sqlite"
         assert result.scheduler.daily_job.jitter_sec == 300
         assert result.scheduler.daily_job.misfire_grace_sec == 1800
+        assert result.retry.max_attempts == 4
+        assert result.retry.min_sec == 1
+        assert result.retry.max_sec == 5

--- a/tests/engine/test_manager.py
+++ b/tests/engine/test_manager.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from sqlalchemy.exc import NoResultFound
 
+from vplan.engine.exception import SmartThingsClientError
 from vplan.engine.manager import (
     refresh_plan_job,
     schedule_daily_refresh,
@@ -191,3 +192,58 @@ class TestRefresh:
         db_retrieve_plan.assert_called_once_with("plan")
         context.assert_called_once_with("token", "loc")
         replace_rules.assert_called_once_with("plan", schema)
+
+    @pytest.mark.parametrize(
+        "max_attempts",
+        [-20, -1, 0, 1],  # any of these values count as only a single attempt (no retries)
+    )
+    def test_refresh_plan_job_fail_no_retry(
+        self,
+        config,
+        db_retrieve_account,
+        db_retrieve_plan_enabled,
+        db_retrieve_plan,
+        replace_rules,
+        context,
+        max_attempts,
+    ):
+        config.return_value = MagicMock(retry=MagicMock(max_attempts=max_attempts, min_sec=0.25, max_sec=1))
+
+        account = MagicMock(pat_token="token")
+        schema = MagicMock(plan=MagicMock(location="loc"))  # because matches the passed-in "loc", it's safe to refresh
+        db_retrieve_account.return_value = account
+        db_retrieve_plan_enabled.return_value = True
+        db_retrieve_plan.return_value = schema
+
+        replace_rules.side_effect = SmartThingsClientError("hello")
+
+        refresh_plan_job("plan", "loc")  # note: exception is swallowed
+
+        db_retrieve_account.assert_called_once()
+        db_retrieve_plan_enabled.assert_called_once_with("plan")
+        db_retrieve_plan.assert_called_once_with("plan")
+        context.assert_called_once_with("token", "loc")
+        replace_rules.assert_called_once_with("plan", schema)
+
+    def test_refresh_plan_job_fail_with_single_retry(
+        self, config, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
+    ):
+        # max_attempts=2 means a single retry (2 total attempts)
+        config.return_value = MagicMock(retry=MagicMock(max_attempts=2, min_sec=0.25, max_sec=1))
+
+        account = MagicMock(pat_token="token")
+        schema = MagicMock(plan=MagicMock(location="loc"))  # because matches the passed-in "loc", it's safe to refresh
+        db_retrieve_account.return_value = account
+        db_retrieve_plan_enabled.return_value = True
+        db_retrieve_plan.return_value = schema
+
+        replace_rules.side_effect = SmartThingsClientError("hello")
+
+        refresh_plan_job("plan", "loc")  # note: exception is swallowed
+
+        # every call is duplicated because we configured retry.max_attempts=2
+        db_retrieve_account.assert_has_calls([call(), call()])
+        db_retrieve_plan_enabled.assert_has_calls([call("plan"), call("plan")])
+        db_retrieve_plan.assert_has_calls([call("plan"), call("plan")])
+        context.assert_called_with("token", "loc")  # the __enter__ and __exit__ calls make it hard to verify this exactly
+        replace_rules.assert_has_calls([call("plan", schema), call("plan", schema)])

--- a/tests/engine/test_manager.py
+++ b/tests/engine/test_manager.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set ft=python ts=4 sw=4 expandtab:
+# pylint: disable=unused-argument:
 import datetime
 from unittest.mock import MagicMock, call, patch
 
@@ -112,9 +113,10 @@ class TestDeviceState:
 @patch("vplan.engine.manager.db_retrieve_plan")
 @patch("vplan.engine.manager.db_retrieve_plan_enabled")
 @patch("vplan.engine.manager.db_retrieve_account")
+@patch("vplan.engine.manager.config")
 class TestRefresh:
     def test_refresh_plan_job_no_account(
-        self, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
+        self, config, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
     ):
         db_retrieve_account.side_effect = NoResultFound("not found")
 
@@ -127,7 +129,7 @@ class TestRefresh:
         replace_rules.assert_not_called()
 
     def test_refresh_plan_job_no_plan(
-        self, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
+        self, config, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
     ):
         account = MagicMock(pat_token="token")
         db_retrieve_account.return_value = account
@@ -142,7 +144,7 @@ class TestRefresh:
         replace_rules.assert_called_once_with("plan", None)
 
     def test_refresh_plan_job_disabled(
-        self, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
+        self, config, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
     ):
         account = MagicMock(pat_token="token")
         db_retrieve_account.return_value = account
@@ -157,7 +159,7 @@ class TestRefresh:
         replace_rules.assert_called_once_with("plan", None)
 
     def test_refresh_plan_job_mismatch(
-        self, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
+        self, config, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
     ):
         account = MagicMock(pat_token="token")
         schema = MagicMock(plan=MagicMock(location="different"))  # because this does not match passed-in "loc", we delete
@@ -174,7 +176,7 @@ class TestRefresh:
         replace_rules.assert_called_once_with("plan", None)
 
     def test_refresh_plan_job_enabled(
-        self, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
+        self, config, db_retrieve_account, db_retrieve_plan_enabled, db_retrieve_plan, replace_rules, context
     ):
         account = MagicMock(pat_token="token")
         schema = MagicMock(plan=MagicMock(location="loc"))  # because matches the passed-in "loc", it's safe to refresh


### PR DESCRIPTION
A few times recently, I've seen problems where the daily refresh fails.  The first problem is that there is not enough context to understand what happened, so I need to improve the logging.  In a larger sense, most problems with the SmartThings infrastructure should be transient, so it makes sense to do some automated retries.  Default configuration retries up to 5 times (6 total attempts) over about a 5 minute period.  I also did some refactoring that should make it easier to retry individual API calls, if that eventually turns out to be a better strategy.