### PR TITLE
Upgrade to Poetry v1.2.0 and other related cleanup

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: ["3.7", "3.8", "3.9", "3.10" ]
+        python: ["3.9", "3.10" ]
     runs-on: ${{ matrix.os }}
     env:
       # Run builds using a specific version of Poetry, to avoid surprises

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,3 +1,4 @@
+# vim: set ft=yaml ts=2 sw=2:
 name: Test Suite
 on:
   push:
@@ -10,11 +11,17 @@ on:
     - cron: '05 17 15 * *'  # 15th of the month at 5:05pm UTC
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: ["3.9", "3.10" ]
+        python: ["3.7", "3.8", "3.9", "3.10" ]
+    runs-on: ${{ matrix.os }}
+    env:
+      # Run builds using a specific version of Poetry, to avoid surprises
+      POETRY_VERSION: "1.2.0"
+      # Prevent Poetry v1.2.0 from using the Python keyring, which sometimes fails or hangs on Linux
+      # See: https://github.com/python-poetry/poetry/issues/2692#issuecomment-1235683370
+      PYTHON_KEYRING_BACKEND: "keyring.backends.null.Keyring"
     steps: 
       - name: Check out code
         uses: actions/checkout@v2
@@ -22,23 +29,51 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Install and configure Poetry
+      - name: Platform information
+        shell: bash
+        run: |
+          # Show platform information
+          python -c "import sys;print('Python %s' % sys.version)"
+      - name: Install Poetry
         uses: snok/install-poetry@v1.2.1 # see https://github.com/snok/install-poetry
         with:
+          version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: true
           virtualenvs-in-project: true
+      - name: Install Poetry plugins
+        shell: bash
+        run: |
+          # Install Poetry plugins
+          poetry self add poetry-plugin-export
+      - name: Cache Poetry dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        run: poetry install -v
+        shell: bash
+        run: |
+          # Install dependencies
+          poetry install --sync
       - name: Upgrade embedded tools within virtualenv
-        run: poetry run pip install --upgrade pip setuptools wheel
+        shell: bash
+        run: |
+          # Upgrade embedded tools
+          poetry run pip install --upgrade pip setuptools wheel
       - name: Run Tox test suite
-        run: poetry run tox -c .toxrc -e "checks,coverage"
+        shell: bash
+        run: |
+          # Run Tox test suite
+          poetry run tox -c .toxrc -e "checks,coverage"
       - name: Upload coverage data to coveralls.io
-        run: poetry run coveralls --service=github
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: ${{ runner.os }}-python${{ matrix.python }}
           COVERALLS_PARALLEL: true
+        run: | 
+          # Upload coverage data to coveralls.io
+          poetry run coveralls --service=github
   coveralls:
     name: Indicate completion to coveralls.io
     needs: build
@@ -46,8 +81,10 @@ jobs:
     container: python:3-slim
     steps:
     - name: Finished
-      run: |
-         pip3 install --upgrade coveralls
-         coveralls --service=github --finish
+      shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Indicate completion to coveralls.io
+        pip3 install --upgrade coveralls
+        coveralls --service=github --finish

--- a/.pylintrc
+++ b/.pylintrc
@@ -74,11 +74,11 @@ disable=fixme,
         too-few-public-methods,
         no-else-return,
         no-else-raise,
+        no-self-use,
         duplicate-code,
         consider-using-f-string,
         no-member, # not reliable for Pydantic; and not really needed because we use MyPy anyway
-        unsubscriptable-object, # bug in Pylint & Python 3.9 gives "Value 'Optional' is unsubscriptable",
-        missing-timeout, # will fix this later
+        unsubscriptable-object # bug in Pylint & Python 3.9 gives "Value 'Optional' is unsubscriptable"
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -74,11 +74,11 @@ disable=fixme,
         too-few-public-methods,
         no-else-return,
         no-else-raise,
-        no-self-use,
         duplicate-code,
         consider-using-f-string,
         no-member, # not reliable for Pydantic; and not really needed because we use MyPy anyway
-        unsubscriptable-object # bug in Pylint & Python 3.9 gives "Value 'Optional' is unsubscriptable"
+        unsubscriptable-object, # bug in Pylint & Python 3.9 gives "Value 'Optional' is unsubscriptable",
+        missing-timeout, # will fix this later
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.toxrc
+++ b/.toxrc
@@ -6,14 +6,14 @@ envlist =
 ignore_basepython_conflict = true
 
 [testenv:checks]
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands =
    poetry --version
    poetry version
    poetry run pre-commit run --all-files --show-diff-on-failure
 
 [testenv:coverage]
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands =
    poetry --version
    poetry version

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,11 @@
+Version 0.5.1     unreleased
+
+	* Upgrade to Poetry v1.2.0 and make related build process changes.
+	* Fix Pylint's configured class-attribute-naming-style to be snake_case.
+	* Adjust Black configuration to target Python 3.7, 3.8, 3.9, and 3.10.
+	* Add dependency caching to GitHub Actions workflow.
+	* Fix the GitHub Actions matrix build to properly target MacOS.
+
 Version 0.5.0     31 May 2022
 
 	* Improve failure logging and add retry behavior for the daily refresh job.

--- a/Changelog
+++ b/Changelog
@@ -2,7 +2,7 @@ Version 0.5.1     unreleased
 
 	* Upgrade to Poetry v1.2.0 and make related build process changes.
 	* Fix Pylint's configured class-attribute-naming-style to be snake_case.
-	* Adjust Black configuration to target Python 3.7, 3.8, 3.9, and 3.10.
+	* Adjust Black configuration to target Python 3.9 and 3.10.
 	* Add dependency caching to GitHub Actions workflow.
 	* Fix the GitHub Actions matrix build to properly target MacOS.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -12,7 +12,7 @@ Uvicorn is using a user-private UNIX socket rather than opening a port like 8080
 
 ## Packaging and Dependencies
 
-This project uses [Poetry](https://python-poetry.org/) to manage Python packaging and dependencies.  Most day-to-day tasks (such as running unit tests from the command line) are orchestrated through Poetry.  
+This project uses [Poetry](https://python-poetry.org/) to manage Python packaging and dependencies.  Most day-to-day tasks (such as running unit tests from the command line) are orchestrated through Poetry.
 
 A coding standard is enforced using [Black](https://github.com/psf/black), [isort](https://pypi.org/project/isort/) and [Pylint](https://www.pylint.org/).  Python 3 type hinting is validated using [MyPy](https://pypi.org/project/mypy/).
 
@@ -42,25 +42,47 @@ in this repository.  Instead of relying on automatic behavior, the
 Nearly all prerequisites are managed by Poetry.  All you need to do is make
 sure that you have a working Python 3 enviroment and install Poetry itself.  
 
-### MacOS
+### Poetry Version
 
-On MacOS, it's easiest to use [Homebrew](https://brew.sh/):
+The project is designed to work with Poetry >= 1.2.0.  If you already have an older
+version of Poetry installed on your system, uninstall it before following the setup
+process below:
 
 ```
-$ brew install python3
-$ brew install poetry
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - --uninstall
+```
+
+See the [Announcing Poetry 1.2.0](https://python-poetry.org/blog/announcing-poetry-1.2.0/)
+blog post for more information.
+
+### MacOS
+
+On MacOS, it's easiest to use [Homebrew](https://brew.sh/) to install Python:
+
+```
+brew install python3
 ```
 
 Once that's done, make sure the `python` on your `$PATH` is Python 3 from
 Homebrew (in `/usr/local`), rather than the standard Python 2 that comes with
 MacOS.
 
+Although Poetry can also be installed from Homebrew, it works better to use
+to [official installer](https://python-poetry.org/docs/#installing-with-the-official-installer):
+
+```
+curl -sSL https://install.python-poetry.org | python3 -
+```
+
+> _Note:_ The installer prints the location of the installed `poetry` script.
+> Make sure to add this to your `$PATH`, otherwise you won't be able to run it.
+
 ### Debian
 
 First, install Python 3 and related tools:
 
 ```
-$ sudo apt-get install python3 python3-venv python3-pip
+sudo apt-get install python3 python3-venv python3-pip
 ```
 
 Next, make sure that the `python` interpreter on your `$PATH` is Python 3.
@@ -71,7 +93,7 @@ However, by default there is only a `python3` interpreter on your `$PATH`, not
 a `python` interpreter.  To add the `python` interpreter, use:
 
 ```
-$ sudo apt-get install python-is-python3
+sudo apt-get install python-is-python3
 ```
 
 For earlier releases of Debian where both Python 2 and Python 3 are available,
@@ -79,12 +101,14 @@ the process is a little more complicated.  The approach I used before upgrading
 to _bullseye_ was based on `update-alternatives`, as discussed on
 [StackExchange](https://unix.stackexchange.com/a/410851).
 
-Once Python 3 is on your `$PATH` as `python`, install Poetry in your home
-directory:
+Next, install Poetry using the [official installer](https://python-poetry.org/docs/#installing-with-the-official-installer):
 
 ```
-$ curl -sSL https://install.python-poetry.org | python3 -
+curl -sSL https://install.python-poetry.org | python3 -
 ```
+
+> _Note:_ The installer prints the location of the installed `poetry` script.
+> Make sure to add this to your `$PATH`, otherwise you won't be able to run it.
 
 ## Developer Tasks
 
@@ -100,7 +124,6 @@ Shortcuts for common developer tasks
 Usage: run <command>
 
 - run install: Setup the virtualenv via Poetry and install pre-commit hooks
-- run activate: Print command needed to activate the Poetry virtualenv
 - run format: Run the code formatters
 - run checks: Run the code checkers
 - run test: Run the unit tests
@@ -136,7 +159,7 @@ order.  In particular, if you do not run the install step, there will be no
 virtualenv for PyCharm to use:
 
 ```
-$ run install && run checks && run test
+run install && run checks && run test
 ```
 
 ### Open the Project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ coveralls = "^3.3.1"
 
 [tool.black]
 line-length = 132
-target-version = ['py37', 'py38', 'py39', 'py310' ]
+target-version = ['py39', 'py310' ]
 include = '(src\/scripts\/.*$|\.pyi?$)'
 exclude = '''
 /(

--- a/run
+++ b/run
@@ -1,12 +1,31 @@
 #!/bin/bash
 # Shortcuts for common developer tasks
 
+disable_keyring() {
+   # Prevent Poetry v1.2.0 from using the Python keyring, which sometimes fails or hangs on Linux
+   # See: https://github.com/python-poetry/poetry/issues/2692#issuecomment-1235683370
+   export PYTHON_KEYRING_BACKEND="keyring.backends.null.Keyring"
+}
+
+enable_keyring() {
+   # We need to unset this for cases where the keyring is required, like publishing
+   unset PYTHON_KEYRING_BACKEND
+}
+
 # Setup the virtual environment via Poetry and install pre-commit hooks
 run_install() {
 
-   # Create and update the virtualenv
-   poetry install -v
+   # Install the poetry-plugin-export plugin, used to generate requirements.txt
+   poetry self add --quiet poetry-plugin-export
    if [ $? != 0 ]; then
+      echo "*** Failed to install Poetry plugin: poetry-plugin-export"
+      exit 1
+   fi
+
+   # Create and update the virtualenv, synchronizing it to versions in poetry.lock
+   poetry install --sync
+   if [ $? != 0 ]; then
+      echo "*** Failed to install dependencies"
       exit 1
    fi
 
@@ -17,14 +36,10 @@ run_install() {
    # Install the pre-commit hooks
    poetry run pre-commit install 
    if [ $? != 0 ]; then
+      echo "*** Failed to install pre-commit hooks"
       exit 1
    fi
 
-}
-
-# Activate the current Poetry virtual environment
-run_activate() {
-   echo "source "$(dirname $(poetry run which python) 2>/dev/null)/activate""
 }
 
 # Run the Pylint code checker
@@ -291,9 +306,6 @@ case $1 in
    install|setup)
       run_install
       ;;
-   activate)
-      run_activate
-      ;;
    black)
       run_black
       ;;
@@ -354,7 +366,6 @@ case $1 in
       echo "Usage: run <command>"  
       echo ""
       echo "- run install: Setup the virtualenv via Poetry and install pre-commit hooks"
-      echo "- run activate: Print command needed to activate the Poetry virtualenv"
       echo "- run format: Run the code formatters"
       echo "- run checks: Run the code checkers"
       echo "- run test: Run the unit tests"


### PR DESCRIPTION
Based on the [changes between apologies v0.1.36 and v0.1.37](https://github.com/pronovic/apologies/compare/v0.1.36..v0.1.37) including [PR #39](https://github.com/pronovic/apologies/pull/39), [PR #40](https://github.com/pronovic/apologies/pull/40), and [PR #41](https://github.com/pronovic/apologies/pull/41).

Changes:

- Upgrade to Poetry v1.2.0
- Add caching to GitHub Actions workflow
- Fix matrix build in GitHub Actions to properly execute on MacOS