### PR TITLE
Fall back addition of timeout for local client calls (unnecessary)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.5.2     unreleased
+
+	* Fall back addition of timeout for local client calls (unnecessary).
+
 Version 0.5.1     05 Sep 2022
 
 	* Upgrade to Poetry v1.2.0 and make related build process changes.

--- a/src/vplan/client/client.py
+++ b/src/vplan/client/client.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set ft=python ts=4 sw=4 expandtab:
+# pylint: disable=missing-timeout: # for the local server, we don't care about timeouts; some requests take a long time
 
 """
 API client written in terms of Python requests.
@@ -14,8 +15,6 @@ from requests import HTTPError, Response
 
 from vplan.client.config import api_url
 from vplan.interface import Account, PlanSchema, Status, Version
-
-_CLIENT_TIMEOUT_SEC = 5.0  # we want some fairly large timeout so that requests can't hang forever
 
 # Add support in requests for http+unix:// URLs to use a UNIX socket
 requests_unixsocket.monkeypatch()
@@ -69,7 +68,7 @@ def retrieve_version() -> Optional[Version]:
 def retrieve_account() -> Optional[Account]:
     """Retrieve account information stored in the plan engine."""
     url = _account()
-    response = requests.get(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.get(url=url)
     if response.status_code == 404:
         return None
     _raise_for_status(response)
@@ -79,21 +78,21 @@ def retrieve_account() -> Optional[Account]:
 def create_or_replace_account(account: Account) -> None:
     """Create or replace account information stored in the plan engine."""
     url = _account()
-    response = requests.post(url=url, data=account.json(), timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.post(url=url, data=account.json())
     _raise_for_status(response)
 
 
 def delete_account() -> None:
     """Delete account information stored in the plan engine."""
     url = _account()
-    response = requests.delete(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.delete(url=url)
     _raise_for_status(response)
 
 
 def retrieve_all_plans() -> List[str]:
     """Return the names of all plans stored in the plan engine."""
     url = _plan()
-    response = requests.get(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.get(url=url)
     _raise_for_status(response)
     plans: List[str] = json.loads(response.text)
     return plans
@@ -102,7 +101,7 @@ def retrieve_all_plans() -> List[str]:
 def retrieve_plan(plan_name: str) -> Optional[PlanSchema]:
     """Return the plan definition stored in the plan engine."""
     url = _plan("/%s" % plan_name)
-    response = requests.get(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.get(url=url)
     if response.status_code == 404:
         return None
     _raise_for_status(response)
@@ -112,28 +111,28 @@ def retrieve_plan(plan_name: str) -> Optional[PlanSchema]:
 def create_plan(schema: PlanSchema) -> None:
     """Create a plan in the plan engine."""
     url = _plan()
-    response = requests.post(url=url, data=schema.json(), timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.post(url=url, data=schema.json())
     _raise_for_status(response)
 
 
 def update_plan(schema: PlanSchema) -> None:
     """Update an existing plan in the plan engine."""
     url = _plan()
-    response = requests.put(url=url, data=schema.json(), timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.put(url=url, data=schema.json())
     _raise_for_status(response)
 
 
 def delete_plan(plan_name: str) -> None:
     """Delete a plan stored in the plan engine."""
     url = _plan("/%s" % plan_name)
-    response = requests.delete(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.delete(url=url)
     _raise_for_status(response)
 
 
 def retrieve_plan_status(plan_name: str) -> Optional[Status]:
     """Return the enabled/disabled status of a plan in the plan engine."""
     url = _plan("/%s/status" % plan_name)
-    response = requests.get(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.get(url=url)
     if response.status_code == 404:
         return None
     _raise_for_status(response)
@@ -143,14 +142,14 @@ def retrieve_plan_status(plan_name: str) -> Optional[Status]:
 def update_plan_status(plan_name: str, status: Status) -> None:
     """Set the enabled/disabled status of a plan in the plan engine."""
     url = _plan("/%s/status" % plan_name)
-    response = requests.put(url=url, data=status.json(), timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.put(url=url, data=status.json())
     _raise_for_status(response)
 
 
 def refresh_plan(plan_name: str) -> None:
     """Refresh the plan rules in the SmartThings infrastructure."""
     url = _plan("/%s/refresh" % plan_name)
-    response = requests.post(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.post(url=url)
     _raise_for_status(response)
 
 
@@ -158,7 +157,7 @@ def toggle_group(plan_name: str, group_name: str, toggles: int, delay_sec: int) 
     """Test a device group that is part of a plan."""
     url = _plan("/%s/test/group/%s" % (plan_name, group_name))
     params = {"toggles": toggles, "delay_sec": delay_sec}
-    response = requests.post(url=url, params=params, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.post(url=url, params=params)
     _raise_for_status(response)
 
 
@@ -166,33 +165,33 @@ def toggle_device(plan_name: str, room: str, device: str, toggles: int, delay_se
     """Test a device that is part of a plan."""
     url = _plan("/%s/test/device/%s/%s" % (plan_name, room, device))
     params = {"toggles": toggles, "delay_sec": delay_sec}
-    response = requests.post(url=url, params=params, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.post(url=url, params=params)
     _raise_for_status(response)
 
 
 def turn_on_group(plan_name: str, group_name: str) -> None:
     """Turn on a device group that is part of a plan."""
     url = _plan("/%s/on/group/%s" % (plan_name, group_name))
-    response = requests.post(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.post(url=url)
     _raise_for_status(response)
 
 
 def turn_on_device(plan_name: str, room: str, device: str) -> None:
     """Turn on a device that is part of a plan."""
     url = _plan("/%s/on/device/%s/%s" % (plan_name, room, device))
-    response = requests.post(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.post(url=url)
     _raise_for_status(response)
 
 
 def turn_off_group(plan_name: str, group_name: str) -> None:
     """Turn off a device group that is part of a plan."""
     url = _plan("/%s/off/group/%s" % (plan_name, group_name))
-    response = requests.post(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.post(url=url)
     _raise_for_status(response)
 
 
 def turn_off_device(plan_name: str, room: str, device: str) -> None:
     """Turn off a device that is part of a plan."""
     url = _plan("/%s/off/device/%s/%s" % (plan_name, room, device))
-    response = requests.post(url=url, timeout=_CLIENT_TIMEOUT_SEC)
+    response = requests.post(url=url)
     _raise_for_status(response)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -118,7 +118,7 @@ class TestAccount:
         result = retrieve_account()
         assert result is None
         raise_for_status.assert_not_called()
-        requests_get.assert_called_once_with(url="http://whatever/account", timeout=5.0)
+        requests_get.assert_called_once_with(url="http://whatever/account")
 
     @patch("vplan.client.client.requests.get")
     def test_retrieve_account_found(self, requests_get, _api_url, raise_for_status):
@@ -128,7 +128,7 @@ class TestAccount:
         result = retrieve_account()
         assert result == account
         raise_for_status.assert_called_once_with(response)
-        requests_get.assert_called_once_with(url="http://whatever/account", timeout=5.0)
+        requests_get.assert_called_once_with(url="http://whatever/account")
 
     @patch("vplan.client.client.requests.post")
     def test_create_or_replace_account(self, requests_post, _api_url, raise_for_status):
@@ -137,7 +137,7 @@ class TestAccount:
         requests_post.side_effect = [response]
         create_or_replace_account(account)
         raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/account", data=account.json(), timeout=5.0)
+        requests_post.assert_called_once_with(url="http://whatever/account", data=account.json())
 
     @patch("vplan.client.client.requests.delete")
     def test_delete_account(self, requests_delete, _api_url, raise_for_status):
@@ -145,7 +145,7 @@ class TestAccount:
         requests_delete.side_effect = [response]
         delete_account()
         raise_for_status.assert_called_once_with(response)
-        requests_delete.assert_called_once_with(url="http://whatever/account", timeout=5.0)
+        requests_delete.assert_called_once_with(url="http://whatever/account")
 
 
 @patch("vplan.client.client._raise_for_status")
@@ -159,7 +159,7 @@ class TestPlan:
         result = retrieve_all_plans()
         assert result == plans
         raise_for_status.assert_called_once_with(response)
-        requests_get.assert_called_once_with(url="http://whatever/plan", timeout=5.0)
+        requests_get.assert_called_once_with(url="http://whatever/plan")
 
     @patch("vplan.client.client.requests.get")
     def test_retrieve_plan_not_found(self, requests_get, _api_url, raise_for_status):
@@ -168,7 +168,7 @@ class TestPlan:
         result = retrieve_plan("xxx")
         assert result is None
         raise_for_status.assert_not_called()
-        requests_get.assert_called_once_with(url="http://whatever/plan/xxx", timeout=5.0)
+        requests_get.assert_called_once_with(url="http://whatever/plan/xxx")
 
     @patch("vplan.client.client.requests.get")
     def test_retrieve_plan_found(self, requests_get, _api_url, raise_for_status):
@@ -178,7 +178,7 @@ class TestPlan:
         result = retrieve_plan("xxx")
         assert result == schema
         raise_for_status.assert_called_once_with(response)
-        requests_get.assert_called_once_with(url="http://whatever/plan/xxx", timeout=5.0)
+        requests_get.assert_called_once_with(url="http://whatever/plan/xxx")
 
     @patch("vplan.client.client.requests.post")
     def test_create_plan(self, requests_post, _api_url, raise_for_status):
@@ -187,7 +187,7 @@ class TestPlan:
         requests_post.side_effect = [response]
         create_plan(schema)
         raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan", data=schema.json(), timeout=5.0)
+        requests_post.assert_called_once_with(url="http://whatever/plan", data=schema.json())
 
     @patch("vplan.client.client.requests.put")
     def test_update_plan(self, requests_put, _api_url, raise_for_status):
@@ -196,7 +196,7 @@ class TestPlan:
         requests_put.side_effect = [response]
         update_plan(schema)
         raise_for_status.assert_called_once_with(response)
-        requests_put.assert_called_once_with(url="http://whatever/plan", data=schema.json(), timeout=5.0)
+        requests_put.assert_called_once_with(url="http://whatever/plan", data=schema.json())
 
     @patch("vplan.client.client.requests.delete")
     def test_delete_plan(self, requests_delete, _api_url, raise_for_status):
@@ -204,7 +204,7 @@ class TestPlan:
         requests_delete.side_effect = [response]
         delete_plan("xxx")
         raise_for_status.assert_called_once_with(response)
-        requests_delete.assert_called_once_with(url="http://whatever/plan/xxx", timeout=5.0)
+        requests_delete.assert_called_once_with(url="http://whatever/plan/xxx")
 
     @patch("vplan.client.client.requests.get")
     def test_retrieve_plan_status_not_found(self, requests_get, _api_url, raise_for_status):
@@ -213,7 +213,7 @@ class TestPlan:
         result = retrieve_plan_status("xxx")
         assert result is None
         raise_for_status.assert_not_called()
-        requests_get.assert_called_once_with(url="http://whatever/plan/xxx/status", timeout=5.0)
+        requests_get.assert_called_once_with(url="http://whatever/plan/xxx/status")
 
     @patch("vplan.client.client.requests.get")
     def test_retrieve_plan_status_found(self, requests_get, _api_url, raise_for_status):
@@ -223,7 +223,7 @@ class TestPlan:
         result = retrieve_plan_status("xxx")
         assert result == status
         raise_for_status.assert_called_once_with(response)
-        requests_get.assert_called_once_with(url="http://whatever/plan/xxx/status", timeout=5.0)
+        requests_get.assert_called_once_with(url="http://whatever/plan/xxx/status")
 
     @patch("vplan.client.client.requests.put")
     def test_update_plan_status(self, requests_put, _api_url, raise_for_status):
@@ -232,7 +232,7 @@ class TestPlan:
         requests_put.side_effect = [response]
         update_plan_status("xxx", status)
         raise_for_status.assert_called_once_with(response)
-        requests_put.assert_called_once_with(url="http://whatever/plan/xxx/status", data=status.json(), timeout=5.0)
+        requests_put.assert_called_once_with(url="http://whatever/plan/xxx/status", data=status.json())
 
     @patch("vplan.client.client.requests.post")
     def test_refresh_plan(self, requests_post, _api_url, raise_for_status):
@@ -240,7 +240,7 @@ class TestPlan:
         requests_post.side_effect = [response]
         refresh_plan("xxx")
         raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/refresh", timeout=5.0)
+        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/refresh")
 
     @patch("vplan.client.client.requests.post")
     def test_toggle_group(self, requests_post, _api_url, raise_for_status):
@@ -248,9 +248,7 @@ class TestPlan:
         requests_post.side_effect = [response]
         toggle_group("xxx", "yyy", 2, 5)
         raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(
-            url="http://whatever/plan/xxx/test/group/yyy", params={"toggles": 2, "delay_sec": 5}, timeout=5.0
-        )
+        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/test/group/yyy", params={"toggles": 2, "delay_sec": 5})
 
     @patch("vplan.client.client.requests.post")
     def test_toggle_device(self, requests_post, _api_url, raise_for_status):
@@ -259,7 +257,7 @@ class TestPlan:
         toggle_device("xxx", "yyy", "zzz", 2, 5)
         raise_for_status.assert_called_once_with(response)
         requests_post.assert_called_once_with(
-            url="http://whatever/plan/xxx/test/device/yyy/zzz", params={"toggles": 2, "delay_sec": 5}, timeout=5.0
+            url="http://whatever/plan/xxx/test/device/yyy/zzz", params={"toggles": 2, "delay_sec": 5}
         )
 
     @patch("vplan.client.client.requests.post")
@@ -268,7 +266,7 @@ class TestPlan:
         requests_post.side_effect = [response]
         turn_on_group("xxx", "yyy")
         raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/on/group/yyy", timeout=5.0)
+        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/on/group/yyy")
 
     @patch("vplan.client.client.requests.post")
     def test_turn_on_device(self, requests_post, _api_url, raise_for_status):
@@ -276,7 +274,7 @@ class TestPlan:
         requests_post.side_effect = [response]
         turn_on_device("xxx", "yyy", "zzz")
         raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/on/device/yyy/zzz", timeout=5.0)
+        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/on/device/yyy/zzz")
 
     @patch("vplan.client.client.requests.post")
     def test_turn_off_group(self, requests_post, _api_url, raise_for_status):
@@ -284,7 +282,7 @@ class TestPlan:
         requests_post.side_effect = [response]
         turn_off_group("xxx", "yyy")
         raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/off/group/yyy", timeout=5.0)
+        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/off/group/yyy")
 
     @patch("vplan.client.client.requests.post")
     def test_turn_off_device(self, requests_post, _api_url, raise_for_status):
@@ -292,4 +290,4 @@ class TestPlan:
         requests_post.side_effect = [response]
         turn_off_device("xxx", "yyy", "zzz")
         raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/off/device/yyy/zzz", timeout=5.0)
+        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/off/device/yyy/zzz")


### PR DESCRIPTION
The change in PR #15 to add a timeout to local API calls was a mistake.  The local API isn't like a typical remote API - the calls are specifically designed to match up with the CLI, and some of them intentionally take a long time.  It still makes sense to time out remote API calls to SmartThings itself, but there's no need for timeouts when invoking the local API.