### PR TITLE
Rewrite tests to use the responses framework

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1177,6 +1177,27 @@ files = [
 requests = ">=1.1"
 
 [[package]]
+name = "responses"
+version = "0.22.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "responses-0.22.0-py3-none-any.whl", hash = "sha256:dcf294d204d14c436fddcc74caefdbc5764795a40ff4e6a7740ed8ddbf3294be"},
+    {file = "responses-0.22.0.tar.gz", hash = "sha256:396acb2a13d25297789a5866b4881cf4e46ffd49cc26c43ab1117f40b973102e"},
+]
+
+[package.dependencies]
+requests = ">=2.22.0,<3.0"
+toml = "*"
+types-toml = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "types-requests"]
+
+[[package]]
 name = "rfc3986"
 version = "1.5.0"
 description = "Validating URI References per RFC 3986"
@@ -1447,6 +1468,18 @@ files = [
 types-urllib3 = "<1.27"
 
 [[package]]
+name = "types-toml"
+version = "0.10.8.5"
+description = "Typing stubs for toml"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-toml-0.10.8.5.tar.gz", hash = "sha256:bf80fce7d2d74be91148f47b88d9ae5adeb1024abef22aa2fdbabc036d6b8b3c"},
+    {file = "types_toml-0.10.8.5-py3-none-any.whl", hash = "sha256:2432017febe43174af0f3c65f03116e3d3cf43e7e1406b8200e106da8cf98992"},
+]
+
+[[package]]
 name = "types-urllib3"
 version = "1.26.25.8"
 description = "Typing stubs for urllib3"
@@ -1636,4 +1669,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "02084ecc2856a49617733c24638755ce3603b4f193a61e911b9276625813e02e"
+content-hash = "2e3defa5e937674d1ad0d20e8399de40024314f71a0b532332884ffc5107d373"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1669,4 +1669,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "2e3defa5e937674d1ad0d20e8399de40024314f71a0b532332884ffc5107d373"
+content-hash = "0d7d82574800f33b96a39673021e740850c62e71ec759358ae3e9bc886768650"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ types-pytz = ">=2022.7.1.2"
 coveralls = "^3.3.1"
 colorama = "~0, >=0.4.5"
 httpx = "~0, >=0.23.3"
-responses = "^0.22.0"
+responses = "~0, >=0.22.0"
 
 [tool.black]
 line-length = 132

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ types-pytz = ">=2022.7.1.2"
 coveralls = "^3.3.1"
 colorama = "~0, >=0.4.5"
 httpx = "~0, >=0.23.3"
+responses = "^0.22.0"
 
 [tool.black]
 line-length = 132

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # vim: set ft=python ts=4 sw=4 expandtab:
 
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+import responses
 from click import ClickException
 from requests import HTTPError, Timeout
+from responses import matchers
 
 from vplan.client.client import (
     _raise_for_status,
@@ -32,18 +33,8 @@ from vplan.client.client import (
 )
 from vplan.interface import Account, Health, Plan, PlanSchema, Status, Version
 
-
-def _response(model=None, data=None, status_code=None):
-    """Build a mocked response for use with the requests library."""
-    response = MagicMock()
-    if model:
-        response.text = model.json()
-    if data:
-        response.text = json.dumps(data)
-    if status_code:
-        response.status_code = status_code
-    response.raise_for_status = MagicMock()
-    return response
+BASE_URL = MagicMock(return_value=MagicMock(return_value="http://whatever"))
+TIMEOUT_MATCHER = matchers.request_kwargs_matcher({"timeout": 1.0})
 
 
 class TestUtil:
@@ -55,239 +46,156 @@ class TestUtil:
             _raise_for_status(response)
 
 
-@patch("vplan.client.client.api_url", new_callable=MagicMock(return_value=MagicMock(return_value="http://whatever")))
+@patch("vplan.client.client.api_url", new_callable=BASE_URL)
 class TestHealthAndVersion:
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_health_error(self, requests_get, _api_url):
-        response = _response()
-        response.raise_for_status.side_effect = HTTPError("error")
-        requests_get.side_effect = [response]
-        assert retrieve_health() is False
-        requests_get.assert_called_once_with(url="http://whatever/health", timeout=1)
+    def test_retrieve_health_error(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/health", status=500, match=[TIMEOUT_MATCHER])
+            assert retrieve_health() is False
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_health_timeout(self, requests_get, _api_url):
-        response = _response()
-        response.raise_for_status.side_effect = Timeout("error")
-        requests_get.side_effect = [response]
-        assert retrieve_health() is False
-        requests_get.assert_called_once_with(url="http://whatever/health", timeout=1)
+    def test_retrieve_health_timeout(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/health", body=Timeout("error"), match=[TIMEOUT_MATCHER])
+            assert retrieve_health() is False
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_health_healthy(self, requests_get, _api_url):
-        response = _response(model=Health())
-        requests_get.side_effect = [response]
-        assert retrieve_health() is True
-        requests_get.assert_called_once_with(url="http://whatever/health", timeout=1)
+    def test_retrieve_health_healthy(self, _):
+        with responses.RequestsMock() as r:
+            health = Health()
+            r.get(url="http://whatever/health", body=health.json(), match=[TIMEOUT_MATCHER])
+            assert retrieve_health() is True
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_version_error(self, requests_get, _api_url):
-        response = _response()
-        response.raise_for_status.side_effect = HTTPError("error")
-        requests_get.side_effect = [response]
-        result = retrieve_version()
-        assert result is None
-        requests_get.assert_called_once_with(url="http://whatever/version", timeout=1)
+    def test_retrieve_version_error(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/version", status=500, match=[TIMEOUT_MATCHER])
+            assert retrieve_version() is None
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_version_timeout(self, requests_get, _api_url):
-        response = _response()
-        response.raise_for_status.side_effect = Timeout("error")
-        requests_get.side_effect = [response]
-        result = retrieve_version()
-        assert result is None
-        requests_get.assert_called_once_with(url="http://whatever/version", timeout=1)
+    def test_retrieve_version_timeout(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/version", body=Timeout("error"), match=[TIMEOUT_MATCHER])
+            assert retrieve_version() is None
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_version_healthy(self, requests_get, _api_url):
-        version = Version(package="a", api="b")
-        response = _response(model=version)
-        requests_get.side_effect = [response]
-        result = retrieve_version()
-        assert result == version
-        requests_get.assert_called_once_with(url="http://whatever/version", timeout=1)
+    def test_retrieve_version_healthy(self, _):
+        with responses.RequestsMock() as r:
+            version = Version(package="a", api="b")
+            r.get(url="http://whatever/version", body=version.json(), match=[TIMEOUT_MATCHER])
+            assert retrieve_version() == version
 
 
-@patch("vplan.client.client._raise_for_status")
-@patch("vplan.client.client.api_url", new_callable=MagicMock(return_value=MagicMock(return_value="http://whatever")))
+@patch("vplan.client.client.api_url", new_callable=BASE_URL)
 class TestAccount:
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_account_not_found(self, requests_get, _api_url, raise_for_status):
-        response = _response(status_code=404)
-        requests_get.side_effect = [response]
-        result = retrieve_account()
-        assert result is None
-        raise_for_status.assert_not_called()
-        requests_get.assert_called_once_with(url="http://whatever/account")
+    def test_retrieve_account_not_found(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/account", status=404)
+            assert retrieve_account() is None
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_account_found(self, requests_get, _api_url, raise_for_status):
-        account = Account(pat_token="token")
-        response = _response(model=account)
-        requests_get.side_effect = [response]
-        result = retrieve_account()
-        assert result == account
-        raise_for_status.assert_called_once_with(response)
-        requests_get.assert_called_once_with(url="http://whatever/account")
+    def test_retrieve_account_found(self, _):
+        with responses.RequestsMock() as r:
+            account = Account(pat_token="token")
+            r.get(url="http://whatever/account", body=account.json())
+            assert retrieve_account() == account
 
-    @patch("vplan.client.client.requests.post")
-    def test_create_or_replace_account(self, requests_post, _api_url, raise_for_status):
-        account = Account(pat_token="token")
-        response = _response()
-        requests_post.side_effect = [response]
-        create_or_replace_account(account)
-        raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/account", data=account.json())
+    def test_create_or_replace_account(self, _):
+        with responses.RequestsMock() as r:
+            account = Account(pat_token="token")
+            r.post(url="http://whatever/account", body=account.json())
+            create_or_replace_account(account)
 
-    @patch("vplan.client.client.requests.delete")
-    def test_delete_account(self, requests_delete, _api_url, raise_for_status):
-        response = _response()
-        requests_delete.side_effect = [response]
-        delete_account()
-        raise_for_status.assert_called_once_with(response)
-        requests_delete.assert_called_once_with(url="http://whatever/account")
+    def test_delete_account(self, _):
+        with responses.RequestsMock() as r:
+            r.delete(url="http://whatever/account")
+            delete_account()
 
 
-@patch("vplan.client.client._raise_for_status")
-@patch("vplan.client.client.api_url", new_callable=MagicMock(return_value=MagicMock(return_value="http://whatever")))
+@patch("vplan.client.client.api_url", new_callable=BASE_URL)
 class TestPlan:
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_all_plans(self, requests_get, _api_url, raise_for_status):
-        plans = ["one", "two"]
-        response = _response(data=plans)
-        requests_get.side_effect = [response]
-        result = retrieve_all_plans()
-        assert result == plans
-        raise_for_status.assert_called_once_with(response)
-        requests_get.assert_called_once_with(url="http://whatever/plan")
+    def test_retrieve_all_plans(self, _):
+        with responses.RequestsMock() as r:
+            plans = ["one", "two"]
+            r.get(url="http://whatever/plan", json=plans)
+            assert retrieve_all_plans() == plans
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_plan_not_found(self, requests_get, _api_url, raise_for_status):
-        response = _response(status_code=404)
-        requests_get.side_effect = [response]
-        result = retrieve_plan("xxx")
-        assert result is None
-        raise_for_status.assert_not_called()
-        requests_get.assert_called_once_with(url="http://whatever/plan/xxx")
+    def test_retrieve_plan_not_found(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/plan/xxx", status=404)
+            assert retrieve_plan("xxx") is None
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_plan_found(self, requests_get, _api_url, raise_for_status):
-        schema = PlanSchema(version="1.0.0", plan=Plan(name="name", location="location", refresh_time="00:30"))
-        response = _response(model=schema)
-        requests_get.side_effect = [response]
-        result = retrieve_plan("xxx")
-        assert result == schema
-        raise_for_status.assert_called_once_with(response)
-        requests_get.assert_called_once_with(url="http://whatever/plan/xxx")
+    def test_retrieve_plan_found(self, _):
+        with responses.RequestsMock() as r:
+            schema = PlanSchema(version="1.0.0", plan=Plan(name="name", location="location", refresh_time="00:30"))
+            r.get(url="http://whatever/plan/xxx", body=schema.json())
+            assert retrieve_plan("xxx") == schema
 
-    @patch("vplan.client.client.requests.post")
-    def test_create_plan(self, requests_post, _api_url, raise_for_status):
-        schema = PlanSchema(version="1.0.0", plan=Plan(name="name", location="location", refresh_time="00:30"))
-        response = _response()
-        requests_post.side_effect = [response]
-        create_plan(schema)
-        raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan", data=schema.json())
+    def test_create_plan(self, _):
+        with responses.RequestsMock() as r:
+            schema = PlanSchema(version="1.0.0", plan=Plan(name="name", location="location", refresh_time="00:30"))
+            r.post(url="http://whatever/plan", body=schema.json())
+            create_plan(schema)
 
-    @patch("vplan.client.client.requests.put")
-    def test_update_plan(self, requests_put, _api_url, raise_for_status):
-        schema = PlanSchema(version="1.0.0", plan=Plan(name="name", location="location", refresh_time="00:30"))
-        response = _response()
-        requests_put.side_effect = [response]
-        update_plan(schema)
-        raise_for_status.assert_called_once_with(response)
-        requests_put.assert_called_once_with(url="http://whatever/plan", data=schema.json())
+    def test_update_plan(self, _):
+        with responses.RequestsMock() as r:
+            schema = PlanSchema(version="1.0.0", plan=Plan(name="name", location="location", refresh_time="00:30"))
+            r.put(url="http://whatever/plan", body=schema.json())
+            update_plan(schema)
 
-    @patch("vplan.client.client.requests.delete")
-    def test_delete_plan(self, requests_delete, _api_url, raise_for_status):
-        response = _response()
-        requests_delete.side_effect = [response]
-        delete_plan("xxx")
-        raise_for_status.assert_called_once_with(response)
-        requests_delete.assert_called_once_with(url="http://whatever/plan/xxx")
+    def test_delete_plan(self, _):
+        with responses.RequestsMock() as r:
+            r.delete(url="http://whatever/plan/xxx")
+            delete_plan("xxx")
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_plan_status_not_found(self, requests_get, _api_url, raise_for_status):
-        response = _response(status_code=404)
-        requests_get.side_effect = [response]
-        result = retrieve_plan_status("xxx")
-        assert result is None
-        raise_for_status.assert_not_called()
-        requests_get.assert_called_once_with(url="http://whatever/plan/xxx/status")
+    def test_retrieve_plan_status_not_found(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/plan/xxx/status", status=404)
+            assert retrieve_plan_status("xxx") is None
 
-    @patch("vplan.client.client.requests.get")
-    def test_retrieve_plan_status_found(self, requests_get, _api_url, raise_for_status):
-        status = Status(enabled=False)
-        response = _response(model=status)
-        requests_get.side_effect = [response]
-        result = retrieve_plan_status("xxx")
-        assert result == status
-        raise_for_status.assert_called_once_with(response)
-        requests_get.assert_called_once_with(url="http://whatever/plan/xxx/status")
+    def test_retrieve_plan_status_found(self, _):
+        with responses.RequestsMock() as r:
+            status = Status(enabled=False)
+            r.get(url="http://whatever/plan/xxx/status", body=status.json())
+            assert retrieve_plan_status("xxx") == status
 
-    @patch("vplan.client.client.requests.put")
-    def test_update_plan_status(self, requests_put, _api_url, raise_for_status):
-        status = Status(enabled=False)
-        response = _response()
-        requests_put.side_effect = [response]
-        update_plan_status("xxx", status)
-        raise_for_status.assert_called_once_with(response)
-        requests_put.assert_called_once_with(url="http://whatever/plan/xxx/status", data=status.json())
+    def test_update_plan_status(self, _):
+        with responses.RequestsMock() as r:
+            status = Status(enabled=False)
+            r.put(url="http://whatever/plan/xxx/status", body=status.json())
+            update_plan_status("xxx", status)
 
-    @patch("vplan.client.client.requests.post")
-    def test_refresh_plan(self, requests_post, _api_url, raise_for_status):
-        response = _response()
-        requests_post.side_effect = [response]
-        refresh_plan("xxx")
-        raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/refresh")
+    def test_refresh_plan(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/refresh")
+            refresh_plan("xxx")
 
-    @patch("vplan.client.client.requests.post")
-    def test_toggle_group(self, requests_post, _api_url, raise_for_status):
-        response = _response()
-        requests_post.side_effect = [response]
-        toggle_group("xxx", "yyy", 2, 5)
-        raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/test/group/yyy", params={"toggles": 2, "delay_sec": 5})
+    def test_toggle_group(self, _):
+        with responses.RequestsMock() as r:
+            r.post(
+                url="http://whatever/plan/xxx/test/group/yyy",
+                match=[matchers.query_param_matcher({"toggles": 2, "delay_sec": 5})],
+            )
+            toggle_group("xxx", "yyy", 2, 5)
 
-    @patch("vplan.client.client.requests.post")
-    def test_toggle_device(self, requests_post, _api_url, raise_for_status):
-        response = _response()
-        requests_post.side_effect = [response]
-        toggle_device("xxx", "yyy", "zzz", "ccc", 2, 5)
-        raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(
-            url="http://whatever/plan/xxx/test/device/yyy/zzz/ccc", params={"toggles": 2, "delay_sec": 5}
-        )
+    def test_toggle_device(self, _):
+        with responses.RequestsMock() as r:
+            r.post(
+                url="http://whatever/plan/xxx/test/device/yyy/zzz/ccc",
+                match=[matchers.query_param_matcher({"toggles": 2, "delay_sec": 5})],
+            )
+            toggle_device("xxx", "yyy", "zzz", "ccc", 2, 5)
 
-    @patch("vplan.client.client.requests.post")
-    def test_turn_on_group(self, requests_post, _api_url, raise_for_status):
-        response = _response()
-        requests_post.side_effect = [response]
-        turn_on_group("xxx", "yyy")
-        raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/on/group/yyy")
+    def test_turn_on_group(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/on/group/yyy")
+            turn_on_group("xxx", "yyy")
 
-    @patch("vplan.client.client.requests.post")
-    def test_turn_on_device(self, requests_post, _api_url, raise_for_status):
-        response = _response()
-        requests_post.side_effect = [response]
-        turn_on_device("xxx", "yyy", "zzz", "ccc")
-        raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/on/device/yyy/zzz/ccc")
+    def test_turn_on_device(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/on/device/yyy/zzz/ccc")
+            turn_on_device("xxx", "yyy", "zzz", "ccc")
 
-    @patch("vplan.client.client.requests.post")
-    def test_turn_off_group(self, requests_post, _api_url, raise_for_status):
-        response = _response()
-        requests_post.side_effect = [response]
-        turn_off_group("xxx", "yyy")
-        raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/off/group/yyy")
+    def test_turn_off_group(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/off/group/yyy")
+            turn_off_group("xxx", "yyy")
 
-    @patch("vplan.client.client.requests.post")
-    def test_turn_off_device(self, requests_post, _api_url, raise_for_status):
-        response = _response()
-        requests_post.side_effect = [response]
-        turn_off_device("xxx", "yyy", "zzz", "ccc")
-        raise_for_status.assert_called_once_with(response)
-        requests_post.assert_called_once_with(url="http://whatever/plan/xxx/off/device/yyy/zzz/ccc")
+    def test_turn_off_device(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/off/device/yyy/zzz/ccc")
+            turn_off_device("xxx", "yyy", "zzz", "ccc")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set ft=python ts=4 sw=4 expandtab:
+# pylint: disable=too-many-public-methods:
 
 from unittest.mock import MagicMock, patch
 
@@ -94,16 +95,35 @@ class TestAccount:
             r.get(url="http://whatever/account", body=account.json())
             assert retrieve_account() == account
 
+    def test_retrieve_account_error(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/account", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                retrieve_account()
+
     def test_create_or_replace_account(self, _):
         with responses.RequestsMock() as r:
             account = Account(pat_token="token")
             r.post(url="http://whatever/account", body=account.json())
             create_or_replace_account(account)
 
+    def test_create_or_replace_account_error(self, _):
+        with responses.RequestsMock() as r:
+            account = Account(pat_token="token")
+            r.post(url="http://whatever/account", body=account.json(), status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                create_or_replace_account(account)
+
     def test_delete_account(self, _):
         with responses.RequestsMock() as r:
             r.delete(url="http://whatever/account")
             delete_account()
+
+    def test_delete_account_error(self, _):
+        with responses.RequestsMock() as r:
+            r.delete(url="http://whatever/account", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                delete_account()
 
 
 @patch("vplan.client.client.api_url", new_callable=BASE_URL)
@@ -113,6 +133,12 @@ class TestPlan:
             plans = ["one", "two"]
             r.get(url="http://whatever/plan", json=plans)
             assert retrieve_all_plans() == plans
+
+    def test_retrieve_all_plans_error(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/plan", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                retrieve_all_plans()
 
     def test_retrieve_plan_not_found(self, _):
         with responses.RequestsMock() as r:
@@ -125,11 +151,24 @@ class TestPlan:
             r.get(url="http://whatever/plan/xxx", body=schema.json())
             assert retrieve_plan("xxx") == schema
 
+    def test_retrieve_plan_error(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/plan/xxx", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                retrieve_plan("xxx")
+
     def test_create_plan(self, _):
         with responses.RequestsMock() as r:
             schema = PlanSchema(version="1.0.0", plan=Plan(name="name", location="location", refresh_time="00:30"))
             r.post(url="http://whatever/plan", body=schema.json())
             create_plan(schema)
+
+    def test_create_plan_error(self, _):
+        with responses.RequestsMock() as r:
+            schema = PlanSchema(version="1.0.0", plan=Plan(name="name", location="location", refresh_time="00:30"))
+            r.post(url="http://whatever/plan", body=schema.json(), status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                create_plan(schema)
 
     def test_update_plan(self, _):
         with responses.RequestsMock() as r:
@@ -137,10 +176,23 @@ class TestPlan:
             r.put(url="http://whatever/plan", body=schema.json())
             update_plan(schema)
 
+    def test_update_plan_error(self, _):
+        with responses.RequestsMock() as r:
+            schema = PlanSchema(version="1.0.0", plan=Plan(name="name", location="location", refresh_time="00:30"))
+            r.put(url="http://whatever/plan", body=schema.json(), status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                update_plan(schema)
+
     def test_delete_plan(self, _):
         with responses.RequestsMock() as r:
             r.delete(url="http://whatever/plan/xxx")
             delete_plan("xxx")
+
+    def test_delete_plan_error(self, _):
+        with responses.RequestsMock() as r:
+            r.delete(url="http://whatever/plan/xxx", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                delete_plan("xxx")
 
     def test_retrieve_plan_status_not_found(self, _):
         with responses.RequestsMock() as r:
@@ -153,16 +205,35 @@ class TestPlan:
             r.get(url="http://whatever/plan/xxx/status", body=status.json())
             assert retrieve_plan_status("xxx") == status
 
+    def test_retrieve_plan_status_error(self, _):
+        with responses.RequestsMock() as r:
+            r.get(url="http://whatever/plan/xxx/status", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                retrieve_plan_status("xxx")
+
     def test_update_plan_status(self, _):
         with responses.RequestsMock() as r:
             status = Status(enabled=False)
             r.put(url="http://whatever/plan/xxx/status", body=status.json())
             update_plan_status("xxx", status)
 
+    def test_update_plan_status_error(self, _):
+        with responses.RequestsMock() as r:
+            status = Status(enabled=False)
+            r.put(url="http://whatever/plan/xxx/status", body=status.json(), status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                update_plan_status("xxx", status)
+
     def test_refresh_plan(self, _):
         with responses.RequestsMock() as r:
             r.post(url="http://whatever/plan/xxx/refresh")
             refresh_plan("xxx")
+
+    def test_refresh_plan_error(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/refresh", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                refresh_plan("xxx")
 
     def test_toggle_group(self, _):
         with responses.RequestsMock() as r:
@@ -172,6 +243,16 @@ class TestPlan:
             )
             toggle_group("xxx", "yyy", 2, 5)
 
+    def test_toggle_group_error(self, _):
+        with responses.RequestsMock() as r:
+            r.post(
+                url="http://whatever/plan/xxx/test/group/yyy",
+                match=[matchers.query_param_matcher({"toggles": 2, "delay_sec": 5})],
+                status=500,
+            )
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                toggle_group("xxx", "yyy", 2, 5)
+
     def test_toggle_device(self, _):
         with responses.RequestsMock() as r:
             r.post(
@@ -180,22 +261,56 @@ class TestPlan:
             )
             toggle_device("xxx", "yyy", "zzz", "ccc", 2, 5)
 
+    def test_toggle_device_error(self, _):
+        with responses.RequestsMock() as r:
+            r.post(
+                url="http://whatever/plan/xxx/test/device/yyy/zzz/ccc",
+                match=[matchers.query_param_matcher({"toggles": 2, "delay_sec": 5})],
+                status=500,
+            )
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                toggle_device("xxx", "yyy", "zzz", "ccc", 2, 5)
+
     def test_turn_on_group(self, _):
         with responses.RequestsMock() as r:
             r.post(url="http://whatever/plan/xxx/on/group/yyy")
             turn_on_group("xxx", "yyy")
+
+    def test_turn_on_group_error(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/on/group/yyy", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                turn_on_group("xxx", "yyy")
 
     def test_turn_on_device(self, _):
         with responses.RequestsMock() as r:
             r.post(url="http://whatever/plan/xxx/on/device/yyy/zzz/ccc")
             turn_on_device("xxx", "yyy", "zzz", "ccc")
 
+    def test_turn_on_device_error(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/on/device/yyy/zzz/ccc", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                turn_on_device("xxx", "yyy", "zzz", "ccc")
+
     def test_turn_off_group(self, _):
         with responses.RequestsMock() as r:
             r.post(url="http://whatever/plan/xxx/off/group/yyy")
             turn_off_group("xxx", "yyy")
 
+    def test_turn_off_group_error(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/off/group/yyy", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                turn_off_group("xxx", "yyy")
+
     def test_turn_off_device(self, _):
         with responses.RequestsMock() as r:
             r.post(url="http://whatever/plan/xxx/off/device/yyy/zzz/ccc")
             turn_off_device("xxx", "yyy", "zzz", "ccc")
+
+    def test_turn_off_device_error(self, _):
+        with responses.RequestsMock() as r:
+            r.post(url="http://whatever/plan/xxx/off/device/yyy/zzz/ccc", status=500)
+            with pytest.raises(ClickException, match=r"500 Server Error"):
+                turn_off_device("xxx", "yyy", "zzz", "ccc")

--- a/tests/engine/test_smartthings.py
+++ b/tests/engine/test_smartthings.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 # vim: set ft=python ts=4 sw=4 expandtab:
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,line-too-long:
 
 import json
 import os
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+import responses
 from requests.models import HTTPError
+from responses import matchers
+from responses.registries import OrderedRegistry
 
 from vplan.engine.exception import InvalidPlanError, SmartThingsClientError
 from vplan.engine.smartthings import (
@@ -74,6 +77,13 @@ EDGE_DEVICE_BY_NAME = {
     "Office/Desk Lamp": "54e6a736-xxxx-xxxx-xxxx-febc0cacd2cc",
 }
 
+TIMEOUT_MATCHER = matchers.request_kwargs_matcher({"timeout": 5.0})
+HEADERS_MATCHER = matchers.header_matcher(HEADERS)
+LIMIT_100_MATCHER = matchers.query_param_matcher({"limit": "100"})
+LIMIT_250_MATCHER = matchers.query_param_matcher({"limit": "250"})
+
+BASE_URL = MagicMock(return_value=MagicMock(return_value="http://whatever"))
+
 
 def fixture(filename: str) -> str:
     """Load fixture JSON data from disk."""
@@ -94,35 +104,57 @@ def _response(data=None, status_code=None):
 
 
 @pytest.fixture
-@patch("vplan.engine.smartthings._base_api_url", new_callable=MagicMock(return_value=MagicMock(return_value="http://whatever")))
-@patch("vplan.engine.smartthings.requests.get")
-def test_context_dth(requests_get, _):
-    locations = fixture("locations.json")
-    rooms = fixture("rooms.json")
-    devices = fixture("dth-devices.json")
-    rules = fixture("rules.json")
-    locations_response = _response(locations)
-    rooms_response = _response(rooms)
-    devices_response = _response(devices)
-    rules_response = _response(rules)
-    requests_get.side_effect = [locations_response, rooms_response, devices_response, rules_response]
-    return SmartThings(PAT_TOKEN, LOCATION)
+@patch("vplan.engine.smartthings._base_api_url", new_callable=BASE_URL)
+def test_context_dth(_):
+    with responses.RequestsMock(registry=OrderedRegistry) as r:
+        r.get(
+            url="http://whatever/locations",
+            body=fixture("locations.json"),
+            match=[TIMEOUT_MATCHER, HEADERS_MATCHER],
+        )
+        r.get(
+            url="http://whatever/locations/%s/rooms" % LOCATION_ID,
+            body=fixture("rooms.json"),
+            match=[TIMEOUT_MATCHER, HEADERS_MATCHER, LIMIT_250_MATCHER],
+        )
+        r.get(
+            url="http://whatever/devices",
+            body=fixture("dth-devices.json"),
+            match=[TIMEOUT_MATCHER, HEADERS_MATCHER],
+        )
+        r.get(
+            url="http://whatever/rules",
+            body=fixture("rules.json"),
+            match=[TIMEOUT_MATCHER, HEADERS_MATCHER],
+        )
+        return SmartThings(PAT_TOKEN, LOCATION)
 
 
 @pytest.fixture
-@patch("vplan.engine.smartthings._base_api_url", new_callable=MagicMock(return_value=MagicMock(return_value="http://whatever")))
-@patch("vplan.engine.smartthings.requests.get")
-def test_context_edge(requests_get, _):
-    locations = fixture("locations.json")
-    rooms = fixture("rooms.json")
-    devices = fixture("edge-devices.json")
-    rules = fixture("rules.json")
-    locations_response = _response(locations)
-    rooms_response = _response(rooms)
-    devices_response = _response(devices)
-    rules_response = _response(rules)
-    requests_get.side_effect = [locations_response, rooms_response, devices_response, rules_response]
-    return SmartThings(PAT_TOKEN, LOCATION)
+@patch("vplan.engine.smartthings._base_api_url", new_callable=BASE_URL)
+def test_context_edge(_):
+    with responses.RequestsMock(registry=OrderedRegistry) as r:
+        r.get(
+            url="http://whatever/locations",
+            body=fixture("locations.json"),
+            match=[TIMEOUT_MATCHER, HEADERS_MATCHER],
+        )
+        r.get(
+            url="http://whatever/locations/%s/rooms" % LOCATION_ID,
+            body=fixture("rooms.json"),
+            match=[TIMEOUT_MATCHER, HEADERS_MATCHER, LIMIT_250_MATCHER],
+        )
+        r.get(
+            url="http://whatever/devices",
+            body=fixture("edge-devices.json"),
+            match=[TIMEOUT_MATCHER, HEADERS_MATCHER],
+        )
+        r.get(
+            url="http://whatever/rules",
+            body=fixture("rules.json"),
+            match=[TIMEOUT_MATCHER, HEADERS_MATCHER],
+        )
+        return SmartThings(PAT_TOKEN, LOCATION)
 
 
 class TestUtil:
@@ -354,16 +386,18 @@ class TestParsers:
             parse_days(days)
 
 
-@patch("vplan.engine.smartthings._raise_for_status")
-@patch("vplan.engine.smartthings._base_api_url", new_callable=MagicMock(return_value=MagicMock(return_value="http://whatever")))
-@patch("vplan.engine.smartthings.requests.get")
+@patch("vplan.engine.smartthings._base_api_url", new_callable=BASE_URL)
 class TestContext:
-    def test_load_context_unknown_location(self, requests_get, _api_url, _):
-        locations = fixture("locations.json")
-        locations_response = _response(locations)
-        requests_get.side_effect = [locations_response]
-        with pytest.raises(SmartThingsClientError, match="^Configured location not found"):
-            SmartThings(pat_token=PAT_TOKEN, location="bogus")
+    def test_load_context_unknown_location(self, _api_url):
+        with responses.RequestsMock() as r:
+            r.get(
+                url="http://whatever/locations",
+                status=200,
+                body=fixture("locations.json"),
+                match=[TIMEOUT_MATCHER],
+            )
+            with pytest.raises(SmartThingsClientError, match="^Configured location not found"):
+                SmartThings(pat_token=PAT_TOKEN, location="bogus")
 
     @pytest.mark.parametrize(
         "devices_file,devices_expected",
@@ -372,68 +406,49 @@ class TestContext:
             ("edge-devices.json", EDGE_DEVICE_BY_NAME),
         ],
     )
-    def test_load_context(self, requests_get, _api_url, raise_for_status, devices_file, devices_expected):
-        locations = fixture("locations.json")
-        rooms = fixture("rooms.json")
-        devices = fixture(devices_file)
-        rules = fixture("rules.json")
-
-        locations_response = _response(locations)
-        rooms_response = _response(rooms)
-        devices_response = _response(devices)
-        rules_response = _response(rules)
-        requests_get.side_effect = [locations_response, rooms_response, devices_response, rules_response]
-
-        with SmartThings(pat_token=PAT_TOKEN, location=LOCATION):
-            context = CONTEXT.get()
-            assert context.pat_token == PAT_TOKEN
-            assert context.location == LOCATION
-            assert context.location_id == LOCATION_ID
-            assert context.headers == HEADERS
-            assert context.room_by_id == ROOM_BY_ID
-            assert context.room_by_name == ROOM_BY_NAME
-            assert context.device_by_name == devices_expected
-            assert len(context.rule_by_id) == 1  # only our managed rules, identified by name, will be included
-            assert context.rule_by_id[RULE_ID]["name"] == RULE_NAME
-
-        with pytest.raises(LookupError):
-            CONTEXT.get()  # the context should not be available outside the SmartThings() block above
-
-        raise_for_status.assert_has_calls(
-            [
-                call(locations_response),
-                call(rooms_response),
-                call(devices_response),
-            ]
-        )
-        requests_get.assert_has_calls(
-            [
-                call(
-                    url="http://whatever/locations",
-                    headers=HEADERS,
-                    params={"limit": "100"},
-                    timeout=5.0,
-                ),
-                call(
-                    url="http://whatever/locations/%s/rooms" % LOCATION_ID,
-                    headers=HEADERS,
-                    params={"limit": "250"},
-                    timeout=5.0,
-                ),
-                call(
-                    url="http://whatever/devices",
-                    headers=HEADERS,
-                    params={"locationId": LOCATION_ID, "capability": "switch", "limit": "1000"},
-                    timeout=5.0,
-                ),
-                call(
-                    url="http://whatever/rules",
-                    headers=HEADERS,
-                    params={"locationId": LOCATION_ID, "limit": "100"},
-                    timeout=5.0,
-                ),
-            ]
-        )
+    def test_load_context(self, _api_url, devices_file, devices_expected):
+        with responses.RequestsMock(registry=OrderedRegistry) as r:
+            r.get(
+                url="http://whatever/locations",
+                body=fixture("locations.json"),
+                match=[TIMEOUT_MATCHER, HEADERS_MATCHER, LIMIT_100_MATCHER],
+            )
+            r.get(
+                url="http://whatever/locations/%s/rooms" % LOCATION_ID,
+                body=fixture("rooms.json"),
+                match=[TIMEOUT_MATCHER, HEADERS_MATCHER, LIMIT_250_MATCHER],
+            )
+            r.get(
+                url="http://whatever/devices",
+                body=fixture(devices_file),
+                match=[
+                    TIMEOUT_MATCHER,
+                    HEADERS_MATCHER,
+                    matchers.query_param_matcher({"locationId": LOCATION_ID, "capability": "switch", "limit": "1000"}),
+                ],
+            )
+            r.get(
+                url="http://whatever/rules",
+                body=fixture("rules.json"),
+                match=[
+                    TIMEOUT_MATCHER,
+                    HEADERS_MATCHER,
+                    matchers.query_param_matcher({"locationId": LOCATION_ID, "limit": "100"}),
+                ],
+            )
+            with SmartThings(pat_token=PAT_TOKEN, location=LOCATION):
+                context = CONTEXT.get()
+                assert context.pat_token == PAT_TOKEN
+                assert context.location == LOCATION
+                assert context.location_id == LOCATION_ID
+                assert context.headers == HEADERS
+                assert context.room_by_id == ROOM_BY_ID
+                assert context.room_by_name == ROOM_BY_NAME
+                assert context.device_by_name == devices_expected
+                assert len(context.rule_by_id) == 1  # only our managed rules, identified by name, will be included
+                assert context.rule_by_id[RULE_ID]["name"] == RULE_NAME
+            with pytest.raises(LookupError):
+                CONTEXT.get()  # the context should not be available outside the SmartThings() block above
 
 
 class TestRules:
@@ -634,99 +649,100 @@ class TestRules:
         _replace_managed_rules.assert_called_once_with("plan", [returned])
 
 
-@patch("vplan.engine.smartthings._raise_for_status")
-@patch("vplan.engine.smartthings._base_api_url", new_callable=MagicMock(return_value=MagicMock(return_value="http://whatever")))
+@patch("vplan.engine.smartthings._base_api_url", new_callable=BASE_URL)
 class TestClient:
-    @patch("vplan.engine.smartthings.requests.delete")
-    def test_delete_rule(self, requests_delete, _, raise_for_status, test_context_dth):
+    def test_delete_rule(self, _, test_context_dth):
         with test_context_dth:
-            response = _response()
-            requests_delete.side_effect = [response]
-            delete_rule("id")
-            raise_for_status.assert_called_once_with(response)
-            requests_delete.assert_called_once_with(
-                url="http://whatever/rules/id", headers=HEADERS, params={"locationId": LOCATION_ID}, timeout=5.0
-            )
+            with responses.RequestsMock() as r:
+                r.delete(
+                    url="http://whatever/rules/id",
+                    status=200,
+                    match=[
+                        TIMEOUT_MATCHER,
+                        HEADERS_MATCHER,
+                        matchers.query_param_matcher({"locationId": LOCATION_ID}),
+                    ],
+                )
+                delete_rule("id")
 
-    @patch("vplan.engine.smartthings.requests.post")
-    def test_create_rule(self, requests_post, _, raise_for_status, test_context_dth):
+    def test_create_rule(self, _, test_context_dth):
+        input_rule = {"input": "value"}
+        output_rule = {"output": "value"}
         with test_context_dth:
-            input_rule = {"input": "value"}
-            output_rule = {"output": "value"}
-            response = _response(data=json.dumps(output_rule))
-            requests_post.side_effect = [response]
-            assert create_rule(input_rule) == output_rule
-            raise_for_status.assert_called_once_with(response)
-            requests_post.assert_called_once_with(
-                url="http://whatever/rules",
-                headers=HEADERS,
-                params={"locationId": LOCATION_ID},
-                json=input_rule,
-                timeout=5.0,
-            )
+            with responses.RequestsMock() as r:
+                r.post(
+                    url="http://whatever/rules",
+                    status=200,
+                    body=json.dumps(output_rule),
+                    match=[
+                        TIMEOUT_MATCHER,
+                        HEADERS_MATCHER,
+                        matchers.query_param_matcher({"locationId": LOCATION_ID}),
+                        matchers.json_params_matcher(input_rule),
+                    ],
+                )
+                assert create_rule(input_rule) == output_rule
 
     @pytest.mark.parametrize(
         "state,command",
         [(SwitchState.ON, "on"), (SwitchState.OFF, "off")],
     )
-    @patch("vplan.engine.smartthings.requests.post")
-    def test_set_switch_dth(self, requests_post, _, raise_for_status, test_context_dth, state, command):
+    def test_set_switch_dth(self, _, test_context_dth, state, command):
         with test_context_dth:
-            response = _response()
-            requests_post.side_effect = [response]
-            set_switch(Device(room="Office", device="Desk Lamp"), state)
-            raise_for_status.assert_called_once_with(response)
-            requests_post.assert_called_once_with(
-                url="http://whatever/devices/54e6a736-xxxx-xxxx-xxxx-febc0cacd2cc/commands",
-                headers=HEADERS,
-                json={"commands": [{"component": "main", "capability": "switch", "command": command}]},
-                timeout=5.0,
-            )
+            with responses.RequestsMock() as r:
+                r.post(
+                    url="http://whatever/devices/54e6a736-xxxx-xxxx-xxxx-febc0cacd2cc/commands",
+                    status=200,
+                    match=[
+                        TIMEOUT_MATCHER,
+                        HEADERS_MATCHER,
+                        matchers.json_params_matcher(
+                            {"commands": [{"component": "main", "capability": "switch", "command": command}]}
+                        ),
+                    ],
+                )
+                set_switch(Device(room="Office", device="Desk Lamp"), state)
 
     @pytest.mark.parametrize(
         "state,command",
         [(SwitchState.ON, "on"), (SwitchState.OFF, "off")],
     )
-    @patch("vplan.engine.smartthings.requests.post")
-    def test_set_switch_edge(self, requests_post, _, raise_for_status, test_context_edge, state, command):
+    def test_set_switch_edge(self, _, test_context_edge, state, command):
         with test_context_edge:
-            response = _response()
-            requests_post.side_effect = [response]
-            set_switch(Device(room="Living Room", device="Tree Outlet", component="leftOutlet"), state)
-            raise_for_status.assert_called_once_with(response)
-            requests_post.assert_called_once_with(
-                url="http://whatever/devices/343345ca-xxxx-xxxx-xxxx-bd52e260583b/commands",
-                headers=HEADERS,
-                json={"commands": [{"component": "leftOutlet", "capability": "switch", "command": command}]},
-                timeout=5.0,
-            )
+            with responses.RequestsMock() as r:
+                r.post(
+                    url="http://whatever/devices/343345ca-xxxx-xxxx-xxxx-bd52e260583b/commands",
+                    status=200,
+                    match=[
+                        TIMEOUT_MATCHER,
+                        HEADERS_MATCHER,
+                        matchers.json_params_matcher(
+                            {"commands": [{"component": "leftOutlet", "capability": "switch", "command": command}]}
+                        ),
+                    ],
+                )
+                set_switch(Device(room="Living Room", device="Tree Outlet", component="leftOutlet"), state)
 
     @pytest.mark.parametrize("file,expected", [("switch_on.json", SwitchState.ON), ("switch_off.json", SwitchState.OFF)])
-    @patch("vplan.engine.smartthings.requests.get")
-    def test_check_switch_dth(self, requests_get, _, raise_for_status, test_context_dth, file, expected):
+    def test_check_switch_dth(self, _, test_context_dth, file, expected):
         with test_context_dth:
-            response = _response(data=fixture(file))
-            requests_get.side_effect = [response]
-            status = check_switch(Device(room="Office", device="Desk Lamp"))
-            assert status == expected
-            raise_for_status.assert_called_once_with(response)
-            requests_get.assert_called_once_with(
-                url="http://whatever/devices/54e6a736-xxxx-xxxx-xxxx-febc0cacd2cc/components/main/capabilities/switch/status",
-                headers=HEADERS,
-                timeout=5.0,
-            )
+            with responses.RequestsMock() as r:
+                r.get(
+                    url="http://whatever/devices/54e6a736-xxxx-xxxx-xxxx-febc0cacd2cc/components/main/capabilities/switch/status",
+                    status=200,
+                    body=fixture(file),
+                    match=[TIMEOUT_MATCHER, HEADERS_MATCHER],
+                )
+                assert check_switch(Device(room="Office", device="Desk Lamp")) == expected
 
     @pytest.mark.parametrize("file,expected", [("switch_on.json", SwitchState.ON), ("switch_off.json", SwitchState.OFF)])
-    @patch("vplan.engine.smartthings.requests.get")
-    def test_check_switch_edge(self, requests_get, _, raise_for_status, test_context_edge, file, expected):
+    def test_check_switch_edge(self, _, test_context_edge, file, expected):
         with test_context_edge:
-            response = _response(data=fixture(file))
-            requests_get.side_effect = [response]
-            status = check_switch(Device(room="Living Room", device="Tree Outlet", component="leftOutlet"))
-            assert status == expected
-            raise_for_status.assert_called_once_with(response)
-            requests_get.assert_called_once_with(
-                url="http://whatever/devices/343345ca-xxxx-xxxx-xxxx-bd52e260583b/components/leftOutlet/capabilities/switch/status",
-                headers=HEADERS,
-                timeout=5.0,
-            )
+            with responses.RequestsMock() as r:
+                r.get(
+                    url="http://whatever/devices/343345ca-xxxx-xxxx-xxxx-bd52e260583b/components/leftOutlet/capabilities/switch/status",
+                    status=200,
+                    body=fixture(file),
+                    match=[TIMEOUT_MATCHER, HEADERS_MATCHER],
+                )
+                assert check_switch(Device(room="Living Room", device="Tree Outlet", component="leftOutlet")) == expected


### PR DESCRIPTION
The unit tests for web client code (that rely on mocking the requests framework) have historically been pretty awkward.  It takes a bunch of code to set up the responses and check the correct behavior.  It turns out that frameworks have been written to simplify this.  Two of these are [responses](https://pypi.org/project/responses/) and [requests-mock](https://pypi.org/project/requests-mock/).  I experimented with both, and found that I preferred responses, so I have rewritten all of the tests to use it.  The framework lets you stub out responses from the server (much like wiremock for Java) and also automatically fails a test if an expected stub isn't invoked.  I think that the tests are more legible now, and they should be easier to maintain.