### PR TITLE
Upgrade to Poetry v1.8.4 to allow official Python 3.13 support later

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,7 @@ Version 0.7.6     unreleased
 	* Update transitive dependencies to address Dependabot warnings.
 	* Update pydantic dependency to deal with problem in Python 3.12.4.
 	* Restrict Python to <3.13 because of limits of pydantic v1 (now EOL).
+	* Upgrade to Poetry v1.8.4 to allow official Python 3.13 support later.
 
 Version 0.7.5     26 Feb 2024
 


### PR DESCRIPTION
This is a mostly-empty PR to force a build with Poetry 1.8.4 in GHA.