### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
     with:
       matrix-os-version: "[ 'ubuntu-latest' ]"
-      matrix-python-version: "[ '3.10', '3.11', '3.12' ]"
+      matrix-python-version: "[ '3.10', '3.11', '3.12', '3.13' ]"
   release:
     name: "Release"
     if: github.ref_type == 'tag'

--- a/Changelog
+++ b/Changelog
@@ -6,7 +6,7 @@ Version 0.7.6     unreleased
 	* Update pydantic dependency to deal with problem in Python 3.12.4.
 	* Upgrade to pydantic v2 and pydantic-yaml v1 and handle interface changes.
 	* Migrate to requests-unixsocket2, which supports newer requests versions.
-	* Upgrade to Poetry v1.8.4 to allow official Python 3.13 support later.
+	* Upgrade to Poetry v1.8.4 for official Python 3.13 support.
 
 Version 0.7.5     26 Feb 2024
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ types-waitress = "^3.0.0"
 
 [tool.black]
 line-length = 132
-target-version = ['py310', 'py311', 'py312' ]
+target-version = ['py310', 'py311', 'py312', 'py313' ]
 include = '(src\/scripts\/.*$|\.pyi?$)'
 exclude = '''
 /(


### PR DESCRIPTION
Now that I upgraded Pydantic in PR #36, we can formally support Python 3.13.