### PR TITLE
Upgrade to gha-shared-workflows@v7 with publish improvements

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,17 +15,17 @@ concurrency:
 jobs:
   linux-build-and-test:
     name: "Linux"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v7
     secrets: inherit
     with:
       matrix-os-version: "[ 'ubuntu-latest' ]"
-      matrix-python-version: "[ '3.10', '3.11', '3.12', '3.13' ]"
+      matrix-python-version: "[ '3.10', '3.11', '3.12', '3.13' ]"  # run Linux tests on all supported Python versions
+      persist-python-version: "3.10"  # persist artifacts for the oldest supported Python version
   release:
     name: "Release"
     if: github.ref_type == 'tag'
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v7
     needs: [ linux-build-and-test ]
     secrets: inherit
     with:
-      python-version: "3.10"   # run release with oldest supported Python version
       publish-pypi: false

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.7.8     unreleased
+
+	* Upgrade to gha-shared-workflows@v7 with publish improvements.
+
 Version 0.7.7     29 Oct 2024
 
 	* Upgrade waitress to address high-severity DOS-related vulnerabilities.


### PR DESCRIPTION
This work was prototyped in a [series of commits in the apologies repo](https://github.com/pronovic/apologies/compare/v0.1.50..v0.1.54).